### PR TITLE
add adc trace function to stm32f373

### DIFF
--- a/hal/stm32f373/Makefile
+++ b/hal/stm32f373/Makefile
@@ -44,13 +44,14 @@ SRC-$(CONFIG_DMA) += ./dma.c
 SRC-$(CONFIG_GPIO) += ./gpio.c
 SRC-$(CONFIG_SPIS) += ./spis.c
 SRC-$(CONFIG_SPIM) += ./spim.c
-SRC-$(CONFIG_ADC) += ./adc.c
+SRC-$(CONFIG_ADC) += ./adc.c ./dma.c
 SRC-$(CONFIG_PWM) += ./pwm.c ./tmr.c
 SRC-$(CONFIG_PPM) += ./ppm.c ./tmr.c
 
 ASRC = ./STM32F37x_DSP_StdPeriph_Lib_V1.0.0/Libraries/CMSIS/Device/ST/STM32F37x/Source/Templates/gcc_ride7/startup_stm32f37x.s
 
-OBJS = $(ASRC:.s=.o) $(SRC:.c=.o) $(SRC-y:.c=.o)
+# turns the src into object, then runs sort to prune any duplicates
+OBJS = $(sort $(ASRC:.s=.o) $(SRC:.c=.o) $(SRC-y:.c=.o))
 
 INCDIR += ../../lib/ \
 	./

--- a/hal/stm32f373/adc.h
+++ b/hal/stm32f373/adc.h
@@ -20,6 +20,16 @@ typedef struct adc_channel_t adc_channel_t;
 
 
 /**
+ * @brief read count values from the adc channel given and call cb when done
+ * @param ch channel to read from
+ * @param dst buffer to store adc vales
+ * @param count number of conversions to do (caller must ensure buf is large enough)
+ */
+typedef void (*adc_trace_complete_t)(adc_channel_t *ch, volatile int16_t *dst, int count, void *param);
+void adc_trace(adc_channel_t *ch, volatile int16_t *dst, int count, adc_trace_complete_t cb, void *param);
+
+
+/**
  * @brief read a single value from the adc channel
  * @param ch channel to read from
  */

--- a/hal/stm32f373/adc_hw.h
+++ b/hal/stm32f373/adc_hw.h
@@ -15,6 +15,7 @@
 
 #include "hal.h"
 #include "gpio_hw.h"
+#include "dma_hw.h"
 
 
 // internal representation of a adc
@@ -24,7 +25,11 @@ struct adc_t
 	SDADC_TypeDef *base;
 	uint32_t ref;
 	SDADC_AINStructTypeDef SDADC_AINStructure[3];
+	uint32_t sadc_clk_div;
+	dma_t *dma;
+
 	bool initalised;
+	dma_request_t dma_req;
 };
 
 
@@ -35,6 +40,11 @@ struct adc_channel_t
 	uint32_t number;
 	uint32_t conf;
 	gpio_pin_t *pin;
+	
+	adc_trace_complete_t complete;
+	void *complete_param;
+	volatile int16_t *buf;
+	int count;
 };
 
 

--- a/utest/adc/adc_utest.py
+++ b/utest/adc/adc_utest.py
@@ -1,0 +1,59 @@
+import struct
+from pylab import *
+import matplotlib.animation as animation
+import subprocess
+import os
+
+def genADCSamples(filename, count=4096):
+    cmd = [
+        # start gdb and connect
+        "arm-none-eabi-gdb",
+        #"-x \"debug_adc_utest.gdbinit\"",
+        "-x \"run_adc_utest.gdbinit\"",
+        # dump adc sample buffer to filename
+        "-ex \"dump binary memory %s &buf[0] (&buf[%d])\"" % (filename, count),
+        # quit
+        "-ex \"quit\"",
+    ]
+    subprocess.call(' '.join(cmd), shell=True)
+
+def loadADCSamples(filename, fmt="H"):
+    buf = open(filename).read()
+    size = struct.Struct(fmt).size
+    u = struct.unpack("<%d" % (len(buf)/size) + fmt, buf)
+    return array(list(u))
+
+def showADCSamples(buf, scale=3.3/65536):
+    fs = 6e6 / 120
+    ts = 1 / fs
+    t = arange(0, (len(buf))*ts, ts)
+    plot(t, buf * scale)
+    grid(True)
+    ylim([0, 3.5])
+    show()
+
+class scope():
+
+    def __init__(self):
+        self.filename = 'adc_cache.bin'
+        self.fs = 6e6 / 120
+        self.ts = 1 / self.fs
+        self.fig = figure()
+        self.ax = self.fig.add_subplot(111)
+        self.ax.set_xlim([0, 4096*self.ts])
+        self.ax.set_ylim([0, 65535])
+        self.traces, = self.ax.plot([], [], '-b')
+        self.anim = animation.FuncAnimation(self.fig, self.animate, interval=1e1, repeat=True, blit=True)
+
+    def animate(self, n):
+        genADCSamples(self.filename)
+        samples = loadADCSamples(self.filename)
+        #samples = rand(4096)
+        t = arange(0, (len(samples))*self.ts, self.ts)
+        self.traces.set_data(t, samples)
+        self.fig.canvas.draw()
+        return self.traces,
+        
+if __name__ == "__main__":
+    s = scope()
+    show()

--- a/utest/adc/config
+++ b/utest/adc/config
@@ -1,3 +1,2 @@
-CONFIG_DMA = n
 CONFIG_GPIO = y
 CONFIG_ADC = y

--- a/utest/adc/hw.c
+++ b/utest/adc/hw.c
@@ -23,88 +23,94 @@
 #include <gpio_hw.h>
 #include <adc_hw.h>
 
-gpio_pin_t adc_chanA_pin = 
+gpio_pin_t adc_pe12_pin = 
 {
 	.port = GPIOE,
 	.cfg = {.GPIO_Pin = GPIO_Pin_12, .GPIO_Mode = GPIO_Mode_AN, 
-			.GPIO_Speed = GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL},
+			.GPIO_PuPd = GPIO_PuPd_NOPULL},
 };
 
 
-gpio_pin_t adc_chanB_pin = 
+gpio_pin_t adc_pe11_pin = 
 {
 	.port = GPIOE,
 	.cfg = {.GPIO_Pin = GPIO_Pin_11, .GPIO_Mode = GPIO_Mode_AN, 
-			.GPIO_Speed = GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL},
+			.GPIO_PuPd = GPIO_PuPd_NOPULL},
 };
 
 
-gpio_pin_t adc_chanC_pin = 
+gpio_pin_t adc_pe10_pin = 
 {
 	.port = GPIOE,
 	.cfg = {.GPIO_Pin = GPIO_Pin_10, .GPIO_Mode = GPIO_Mode_AN, 
-			.GPIO_Speed = GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL},
+			.GPIO_PuPd = GPIO_PuPd_NOPULL},
 };
 
 
-gpio_pin_t adc_chanD_pin = 
+gpio_pin_t adc_pe9_pin = 
 {
 	.port = GPIOE,
 	.cfg = {.GPIO_Pin = GPIO_Pin_9, .GPIO_Mode = GPIO_Mode_AN, 
-			.GPIO_Speed = GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL},
+			.GPIO_PuPd = GPIO_PuPd_NOPULL},
 };
 
 
-adc_t adc0 =
+dma_t adc1_dma =
+{
+	.channel = DMA2_Channel3,
+};
+
+
+adc_t adc1 =
 {
 	.base = SDADC1,
 	.ref = SDADC_VREF_Ext,
 	.SDADC_AINStructure = 
 	{
 		{.SDADC_InputMode = SDADC_InputMode_SEZeroReference, .SDADC_Gain = SDADC_Gain_1,
-			.SDADC_CommonMode = SDADC_CommonMode_VSSA, .SDADC_Offset = 0},
+			.SDADC_CommonMode = SDADC_CommonMode_VSSA},
 		{.SDADC_InputMode = SDADC_InputMode_SEZeroReference, .SDADC_Gain = SDADC_Gain_1,
-			.SDADC_CommonMode = SDADC_CommonMode_VSSA, .SDADC_Offset = 0},
+			.SDADC_CommonMode = SDADC_CommonMode_VSSA},
 		{.SDADC_InputMode = SDADC_InputMode_SEZeroReference, .SDADC_Gain = SDADC_Gain_1,
-			.SDADC_CommonMode = SDADC_CommonMode_VSSA, .SDADC_Offset = 0},
+			.SDADC_CommonMode = SDADC_CommonMode_VSSA},
 	},
+	.dma = &adc1_dma,
 };
 
 
 adc_channel_t adc_chanA =
 {
-	.adc = &adc0,
+	.adc = &adc1,
 	.number = SDADC_Channel_0,
 	.conf = SDADC_Conf_0,
-	.pin = &adc_chanA_pin,
+	.pin = &adc_pe12_pin,
 };
 
 
 adc_channel_t adc_chanB =
 {
-	.adc = &adc0,
+	.adc = &adc1,
 	.number = SDADC_Channel_1,
 	.conf = SDADC_Conf_0,
-	.pin = &adc_chanB_pin,
+	.pin = &adc_pe11_pin,
 };
 
 
 adc_channel_t adc_chanC =
 {
-	.adc = &adc0,
+	.adc = &adc1,
 	.number = SDADC_Channel_2,
 	.conf = SDADC_Conf_0,
-	.pin = &adc_chanC_pin,
+	.pin = &adc_pe10_pin,
 };
 
 
 adc_channel_t adc_chanD =
 {
-	.adc = &adc0,
+	.adc = &adc1,
 	.number = SDADC_Channel_7,
 	.conf = SDADC_Conf_0,
-	.pin = &adc_chanD_pin,
+	.pin = &adc_pe9_pin,
 };
-
 
 #endif

--- a/utest/adc/run_adc_utest.gdbinit
+++ b/utest/adc/run_adc_utest.gdbinit
@@ -1,0 +1,12 @@
+target remote localhost:3333
+set confirm off
+delete
+
+file adc_utest.elf
+tbreak adc_handle_buffer
+c
+
+define reset
+	mon reset halt
+end
+


### PR DESCRIPTION
a trace samples the ADC a given number of times into a given buffer

note on the stm32f373 the ADC is all one in HW using a DMA atm so a DMA
channel is required to use the trace, but there are virtually no
software overheads to run a trace with DMA

I have also added a handy unit test of the firmware, the adc_utest.py
talks to the firmware via gdb and displays the trace data using
matplotlib like a very simple scope

@todo support ISR mode
@todo allow triggering from another peripheral, ie timer/comparitor etc
@todo sync mode (allow adcs to run in sync mode for parallel sampled
traces