### PR TITLE
@72MHz (default) the stm32f373 need 2 wait states for flash

### DIFF
--- a/hal/stm32f373/sys.c
+++ b/hal/stm32f373/sys.c
@@ -48,7 +48,7 @@ static void sys_clk_init(void)
 	FLASH_PrefetchBufferCmd(ENABLE);
 
 	// Flash 1 wait state
-	FLASH_SetLatency(FLASH_Latency_1);
+	FLASH_SetLatency(FLASH_Latency_2);
 
 	// AHB prescaler set to div 1, HCLK = SYSCLK (72MHz)
 	RCC_HCLKConfig(RCC_SYSCLK_Div1);


### PR DESCRIPTION
ops, I don't know how I overlooked this, but everything seems to run
with 1 wait state (somehow), but this makes it right according to the
documentation