### PR TITLE
allow spim xfers to specify their own options

### DIFF
--- a/hal/stm32f373/spi.c
+++ b/hal/stm32f373/spi.c
@@ -44,6 +44,22 @@ void spi_clk_init(SPI_TypeDef *channel)
 }
 
 
+float spi_get_clk_speed(SPI_TypeDef *channel)
+{
+	switch ((uint32_t)channel)
+	{
+		case (uint32_t)SPI1:
+			// on apb2 bus so full speed
+			return sys_clk_freq();
+		case (uint32_t)SPI2:
+		case (uint32_t)SPI3:
+		default:
+			// on apb1 bus so 1/2 speed
+			return sys_clk_freq() / 2.0;
+	}
+}
+
+
 void spi_init_regs(SPI_TypeDef *channel, SPI_InitTypeDef *st_spi_init_in)
 {
 	// init the spi itself

--- a/hal/stm32f373/spi.h
+++ b/hal/stm32f373/spi.h
@@ -24,6 +24,8 @@ void spi_gpio_init(gpio_pin_t *nss, gpio_pin_t *sck, gpio_pin_t *miso, gpio_pin_
 
 void spi_clk_init(SPI_TypeDef *channel);
 
+float spi_get_clk_speed(SPI_TypeDef *channel);
+
 void spi_init_regs(SPI_TypeDef *channel, SPI_InitTypeDef *st_spi_init_in);
 
 void spi_flush_tx_fifo(SPI_TypeDef *channel, SPI_InitTypeDef *st_spi_init);

--- a/hal/stm32f373/spim.c
+++ b/hal/stm32f373/spim.c
@@ -196,7 +196,7 @@ success:
 	sys_enter_critical_section();
 
 	if (spim->read_buf != NULL || spim->read_count != 0 ||
-	    spim->write_buf != NULL || spim->write_count != 0)
+		spim->write_buf != NULL || spim->write_count != 0)
 		///@todo xfer in progress already
 		goto done;
 
@@ -213,8 +213,6 @@ success:
 	// flush the buffers so the xfer begins a new
 	spi_flush_rx_fifo(spim->channel);
 	spi_flush_tx_fifo(spim->channel, &opts->st_opts);
-
-	// init the spi setup for this transfer
 
 	// init the read
 	if (len == 1 || spim->rx_dma == NULL)

--- a/hal/stm32f373/spim.h
+++ b/hal/stm32f373/spim.h
@@ -21,6 +21,12 @@ typedef struct spim_t spim_t;
 
 
 /**
+ * @brief opaque master spi transfer options
+ */
+typedef struct spim_xfer_opts spim_xfer_opts;
+
+
+/**
  * @brief setup the master spi device
  * @param spim spi master to init
  */
@@ -42,6 +48,7 @@ typedef void (*spim_xfer_complete)(spim_t *spim, uint16_t addr, void *read_buf, 
 /**
  * @brief start a spi master transfer
  * @param spim spi master to use
+ * @param opts options for this spi transfer (ie CPOL/CPHA, etc)
  * @param addr address of the slave to xfer to
  * @param read_len fill this many bytes into the read buf
  * @param write_buf send data from here to the MOSI
@@ -49,7 +56,7 @@ typedef void (*spim_xfer_complete)(spim_t *spim, uint16_t addr, void *read_buf, 
  * @param complete call this when len bytes are transfered
  * @param param complete parameter
  */
-void spim_xfer(spim_t *spim, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param);
+void spim_xfer(spim_t *spim, spim_xfer_opts *opts, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param);
 
 
 /**

--- a/hal/stm32f373/spim_hw.h
+++ b/hal/stm32f373/spim_hw.h
@@ -26,7 +26,6 @@ struct spim_xfer_opts
 struct spim_t
 {
 	SPI_TypeDef *channel;
-	//SPI_InitTypeDef st_spi_init;					///< details of how the spim should run (not all options are supported yet)
 	uint16_t idle_address;							///< address to select when the bus is idle
 
 	// device pins

--- a/hal/stm32f373/spim_hw.h
+++ b/hal/stm32f373/spim_hw.h
@@ -16,16 +16,21 @@
 #include "hal.h"
 #include "dma_hw.h"
 
+struct spim_xfer_opts
+{
+	uint32_t speed; 			///< go equal to or slower than this, or if 0 use st_opts.SPI_BaudRatePrescaler
+	SPI_InitTypeDef st_opts; 	///< spi setup for a particular transaction
+};
 
 // internal representation of a master spi device
 struct spim_t
 {
 	SPI_TypeDef *channel;
-	SPI_InitTypeDef st_spi_init;					///< details of how the spim should run (not all options are supported yet)
+	//SPI_InitTypeDef st_spi_init;					///< details of how the spim should run (not all options are supported yet)
 	uint16_t idle_address;							///< address to select when the bus is idle
 
 	// device pins
-	gpio_pin_t **nss;								///< null terminated array of address pin where the first item is the LSB and the last is the MSB in the address
+	gpio_pin_t **nss;								///< null terminated array of address pin where the first item is the LSB and the last is the MSB in the address .. to use HW controlled NSS set st_opts.SPI_NSS = SPI_NSS_Hard and this to NULL
 	gpio_pin_t *sck, *miso, *mosi;					///< other standard spi lines
 
 	// transfer

--- a/utest/spi/hw.c
+++ b/utest/spi/hw.c
@@ -79,11 +79,18 @@
 	};
 	
 	#include <spim_hw.h>
+	spim_xfer_opts spim_dev_opts =
+	{
+		.speed = 0,
+		.st_opts = {SPI_Direction_2Lines_FullDuplex, SPI_Mode_Master, 
+					SPI_DataSize_8b, SPI_CPOL_Low, SPI_CPHA_1Edge, SPI_NSS_Soft, 
+					SPI_BaudRatePrescaler_256, SPI_FirstBit_MSB, 0},
+	};
+
 	gpio_pin_t *spim_dev_nss[] = {&gpio_spi1_nss, NULL};
 	spim_t spim_dev =
 	{
 		.channel = SPI1,   // channel
-		.st_spi_init = {SPI_Direction_2Lines_FullDuplex, SPI_Mode_Master, SPI_DataSize_8b, SPI_CPOL_Low, SPI_CPHA_1Edge, SPI_NSS_Soft, SPI_BaudRatePrescaler_256, SPI_FirstBit_MSB, 0},
 		.idle_address = 0x00, // bus should go to this state when idle
 		.nss = spim_dev_nss, // nss/address lines
 		.sck = &gpio_spi1_sck, // clk line gpio

--- a/utest/spi/hw.h
+++ b/utest/spi/hw.h
@@ -22,6 +22,7 @@ extern spis_t spis_dev;
 /**
  * master spi device available oh this hw
  */
+extern spim_xfer_opts spim_dev_opts;
 extern spim_t spim_dev;
 
 #endif

--- a/utest/spi/spi_utest.c
+++ b/utest/spi/spi_utest.c
@@ -81,7 +81,7 @@ int main(void)
 	init();
 	spis_write(&spis_dev, spis_write_buf, WRITE_BUF_LEN, spis_writecomplete, NULL);
 	spis_read(&spis_dev, spis_read_buf, READ_BUF_LEN, spis_readcomplete, NULL);
-	spim_xfer(&spim_dev, 0x01, spim_read_buf, spim_write_buf, SPIM_LEN, spim_complete, NULL);
+	spim_xfer(&spim_dev, &spim_dev_opts, 0x01, spim_read_buf, spim_write_buf, SPIM_LEN, spim_complete, NULL);
 
 	// do nothing
 	while (1)
@@ -90,7 +90,7 @@ int main(void)
 		{
 			again = 0;
 			sys_spin(20);
-			spim_xfer(&spim_dev, 0x01, spim_read_buf, spim_write_buf, SPIM_LEN, spim_complete, NULL);
+			spim_xfer(&spim_dev, &spim_dev_opts, 0x01, spim_read_buf, spim_write_buf, SPIM_LEN, spim_complete, NULL);
 		}
 	}
 


### PR DESCRIPTION
this basically changes spim_xfer to take an additional options pointer
that points to the setup for this particular transfer, eg this allows
talking to 1 address using CPHA_1Edge and another address using
CPHA_2Edge so the packet tailored towards the target device

note these options are necessarily platform specific

for the stm32f373 I have included a speed option and it will try to find
a speed as fast as possible but still slow than this using its
pre scalers, if this is 0 then it will use the pre scaler set in the
st_opts struct

I have also updated the spi unit test to support this new API