### PR TITLE
add tmr frequency change callback for pwm, ppm etc

### DIFF
--- a/hal/stm32f373/tmr.h
+++ b/hal/stm32f373/tmr.h
@@ -61,6 +61,17 @@ uint32_t tmr_set_freq(tmr_t *tmr, uint32_t freq);
 
 
 /**
+ * @brief add callback to run for each channel when this timer changes its frequency
+ * @param tmr timer to connect the callback
+ * @param cb callback function
+ * @param channel indicates which channel on the timer this is called for
+ * @param param callback parameter
+ */
+typedef void (*freq_update_cb_t)(tmr_t *tmr, int ch, void *param); // internal callback for pwm/ppm modules etc
+void tmr_set_freq_update_cb(tmr_t *tmr, freq_update_cb_t cb, int channel, void *param); // internal function only
+
+
+/**
  * @brief get the tick count of the timer
  * @param tmr the timer to get the tick count of
  * @return the tick count of the timer

--- a/hal/stm32f373/tmr_hw.h
+++ b/hal/stm32f373/tmr_hw.h
@@ -34,6 +34,9 @@ struct tmr_t
 		uint16_t output_trigger;	// see TIM_Trigger_Output_Source
 		uint16_t input_trigger;		// see TIM_Internal_Trigger_Selection (table 45 in reference manual)
 	} sync;
+
+	freq_update_cb_t freq_update_cb[4];
+	void *freq_update_cb_param[4];
 };
 
 #endif

--- a/utest/ppm/ppm_utest.c
+++ b/utest/ppm/ppm_utest.c
@@ -27,10 +27,12 @@ void init(void)
 int main(void)
 {
 	float phs = 0;
+
 	init();
 	ppm_start(&ppm_ref);
 	ppm_start(&ppm_drift);
 
+	ppm_set_freq(&ppm_drift, 10000); // test overriding hw.c freq and ensure ch2 updates phs too
 	while (1)
 	{
 		ppm_set_phs(&ppm_drift, phs);

--- a/utest/pwm/hw.c
+++ b/utest/pwm/hw.c
@@ -83,4 +83,45 @@ pwm_channel_t pwm1 = {
 				.TIM_OCPolarity = TIM_OCPolarity_Low}
 };
 
+gpio_pin_t pc12 = 
+{
+	.port = GPIOC,
+	.cfg = {.GPIO_Pin = GPIO_Pin_12, .GPIO_Mode = GPIO_Mode_AF,
+			.GPIO_Speed = GPIO_Speed_50MHz, .GPIO_OType = GPIO_OType_PP, 
+			.GPIO_PuPd = GPIO_PuPd_NOPULL},
+	.af = 2,
+};
+
+gpio_pin_t pc11 = 
+{
+	.port = GPIOC,
+	.cfg = {.GPIO_Pin = GPIO_Pin_11, .GPIO_Mode = GPIO_Mode_AF,
+			.GPIO_Speed = GPIO_Speed_50MHz, .GPIO_OType = GPIO_OType_PP, 
+			.GPIO_PuPd = GPIO_PuPd_NOPULL},
+	.af = 2,
+};
+
+tmr_t tmr19 = {
+	.tim = TIM19,
+	.freq = 1000,
+};
+
+pwm_channel_t pwm2 = {
+	.tmr = &tmr19,
+	.pin = &pc11,
+	.ch = TIM_Channel_2,
+	.duty = 0.25,
+	.oc_cfg = { .TIM_OCMode = TIM_OCMode_PWM1, .TIM_OutputState = TIM_OutputState_Enable,
+				.TIM_OCPolarity = TIM_OCPolarity_Low}
+};
+
+pwm_channel_t pwm3 = {
+	.tmr = &tmr19,
+	.pin = &pc12,
+	.ch = TIM_Channel_3,
+	.duty = 0.75,
+	.oc_cfg = { .TIM_OCMode = TIM_OCMode_PWM1, .TIM_OutputState = TIM_OutputState_Enable,
+				.TIM_OCPolarity = TIM_OCPolarity_Low}
+};
+
 #endif

--- a/utest/pwm/hw.h
+++ b/utest/pwm/hw.h
@@ -16,6 +16,8 @@
 
 extern pwm_channel_t pwm0;
 extern pwm_channel_t pwm1;
+extern pwm_channel_t pwm2;
+extern pwm_channel_t pwm3;
 
 extern tmr_t tmr3;
 extern tmr_t tmr4;

--- a/utest/pwm/pwm_utest.c
+++ b/utest/pwm/pwm_utest.c
@@ -21,6 +21,8 @@ void init(void)
 	sys_init();
 	pwm_init(&pwm0);
 	pwm_init(&pwm1);
+	pwm_init(&pwm2);
+	pwm_init(&pwm3);
 }
 
 int main(void)
@@ -30,6 +32,8 @@ int main(void)
 	pwm_start(&pwm1);
 	sys_spin(2); // adds a phase shift that should go away in SYNC mode
 	pwm_start(&pwm0);
+	pwm_start(&pwm3);
+	pwm_set_freq(&pwm3, 50000); // test overriding hw.c freq and ensure pwm2 updates duty too
 		
 	while (1)
 	{}


### PR DESCRIPTION
this fixes a bug where if the pwm/ppm etc change their frequency
(period) then the duty cycle and phase etc change (sometimes never
trigger as the ARR reg < CCRx reg) ... this is done in a fairly tidy way
with a callback for each timer channel that is run when ever the
frequency is set, then the ppm or pwm etc can just set the phase or duty
again in these callbacks so they will update with the frequency