### PR TITLE
add timer (tmr) as its own module

### DIFF
--- a/hal/stm32f373/Makefile
+++ b/hal/stm32f373/Makefile
@@ -47,6 +47,7 @@ SRC-$(CONFIG_GPIO) += ./gpio.c
 SRC-$(CONFIG_SPIS) += ./spis.c
 SRC-$(CONFIG_SPIM) += ./spim.c
 SRC-$(CONFIG_ADC) += ./adc.c ./dma.c
+SRC-$(CONFIG_TMR) += ./tmr.c
 SRC-$(CONFIG_PWM) += ./pwm.c ./tmr.c
 SRC-$(CONFIG_PPM) += ./ppm.c ./tmr.c
 SRC-$(CONFIG_UART) += ./uart.c

--- a/hal/stm32f373/tmr.h
+++ b/hal/stm32f373/tmr.h
@@ -72,6 +72,16 @@ void tmr_set_freq_update_cb(tmr_t *tmr, freq_update_cb_t cb, int channel, void *
 
 
 /**
+ * @brief add callback to run when the timer update event occurs
+ * @param tmr timer to connect the callback
+ * @param cb callback function
+ * @param param callback parameter
+ */
+typedef void (*tmr_update_cb_t)(tmr_t *tmr, void *param);
+void tmr_set_update_cb(tmr_t *tmr, tmr_update_cb_t cb, void *param);
+
+
+/**
  * @brief get the tick count of the timer
  * @param tmr the timer to get the tick count of
  * @return the tick count of the timer

--- a/hal/stm32f373/tmr_hw.h
+++ b/hal/stm32f373/tmr_hw.h
@@ -37,6 +37,9 @@ struct tmr_t
 
 	freq_update_cb_t freq_update_cb[4];
 	void *freq_update_cb_param[4];
+
+	tmr_update_cb_t update_cb;
+	void *update_cb_param;
 };
 
 #endif


### PR DESCRIPTION
although the tmr module is used by some other modules (ie pwm, ppm etc)
this allows the tmr module to be used by itself ... it can be started,
stopped, etc and a new update isr event is available which is called
when the timer overflows (useful for setting hard timeouts)

note this tmr is the master level and the ppm and pwm channels will have
a master tmr and no attempt is made to share these nicely ... it is up
to the developer to use these properly!