### PR TITLE
rework _sbrk for malloc heap allocation

### DIFF
--- a/hal/stm32f373/syscalls.c
+++ b/hal/stm32f373/syscalls.c
@@ -32,14 +32,13 @@ int _read(int file, char *ptr, int len)
 	return 0;
 }
 
-#ifdef USE_HEAP
+weak unsigned char _heap_low; // defined by the linker
+weak unsigned char _heap_top; // "
 caddr_t _sbrk(int incr)
 {
 	// bare bones heap allocator
 	static unsigned char *heap_end = 0;
 	unsigned char *prev_heap_end;
-	extern unsigned char _heap_low; // defined by the linker
-	extern unsigned char _heap_top; // "
 
 	// initialize
 	if(heap_end == 0)
@@ -53,12 +52,6 @@ caddr_t _sbrk(int incr)
 
 	return (caddr_t) prev_heap_end;
 }
-#else
-caddr_t _sbrk(int incr)
-{
-	return (caddr_t)0;
-}
-#endif
  
 int _write(int file, char *ptr, int len)
 {


### PR DESCRIPTION
passing the #define around for the HEAP is messy and hard to test,
instead I by alloc _heap_low and _heap_top as weak aligned variables,
that way if they are defined in the linker you get a bigger heap, but
otherwise you heap of size 1 byte (essentially no heap so unless you
alloc 1 byte all alloc calls fail and return NULL as before) ... this
makes the behaviour more consistent and easier to test (ie no special
edge cases) and also the heap is only configured in one place, ie the
linker script