### PR TITLE
add uart api to get number of words sent

### DIFF
--- a/hal/stm32f373/dma.c
+++ b/hal/stm32f373/dma.c
@@ -280,6 +280,12 @@ void dma_request(dma_request_t *req)
 	DMA_Cmd(dma->channel, ENABLE);
 }
 
+int dma_remaining(dma_request_t *req)
+{
+	dma_t *dma = req->dma;
+	return dma->channel->CNDTR;
+}
+
 void dma_cancel(dma_t *dma)
 {
 	if (dma == NULL)

--- a/hal/stm32f373/dma_hw.h
+++ b/hal/stm32f373/dma_hw.h
@@ -28,6 +28,8 @@ struct dma_request_t
 
 void dma_request(dma_request_t *req);
 
+int dma_remaining(dma_request_t *req);
+
 struct dma_t
 {
 	DMA_Channel_TypeDef *channel;

--- a/hal/stm32f373/uart.c
+++ b/hal/stm32f373/uart.c
@@ -324,6 +324,19 @@ done:
 }
 
 
+int uart_read_count(uart_t *uart)
+{
+	if (uart->read_buf_len == 0)
+		// no read in progress
+		return -1;
+
+	if (uart->rx_dma)
+		return uart->read_buf_len - dma_remaining(&uart->rx_dma_req);
+	else
+		return uart->read_count;
+}
+
+
 void uart_cancel_read(uart_t *uart)
 {
 	sys_enter_critical_section();
@@ -370,6 +383,19 @@ void uart_write(uart_t *uart, void *buf, uint16_t len, uart_write_complete_cb cb
 done:
 	sys_leave_critical_section();
 	return;
+}
+
+
+int uart_write_count(uart_t *uart)
+{
+	if (uart->write_buf_len == 0)
+		// no write in progress
+		return -1;
+
+	if (uart->tx_dma)
+		return uart->write_buf_len - dma_remaining(&uart->tx_dma_req);
+	else
+		return uart->write_count;
 }
 
 

--- a/hal/stm32f373/uart.h
+++ b/hal/stm32f373/uart.h
@@ -54,6 +54,14 @@ typedef void (*uart_write_complete_cb)(uart_t *uart, void *buf, uint16_t len, vo
  */
 void uart_write(uart_t *uart, void *buf, uint16_t len, uart_write_complete_cb cb, void *param);
 
+
+/**
+ * @brief return the number of bytes written so far
+ * @param uart uart device being written to
+ */
+int uart_write_count(uart_t *uart);
+
+
 /**
  * @brief cancel uart write
  * @param uart uart device to cancel write on
@@ -80,6 +88,13 @@ typedef void (*uart_read_complete_cb)(uart_t *uart, void *buf, uint16_t len, voi
  * @param param parameter passed to the completion callback
  */
 void uart_read(uart_t *uart, void *buf, uint16_t len, uart_read_complete_cb cb, void *param);
+
+
+/**
+ * @brief return the number of bytes read so far
+ * @param uart uart device being read from
+ */
+int uart_read_count(uart_t *uart);
 
 
 /**


### PR DESCRIPTION
this is useful in the foreground task to see how the uart is progressing
or adding a timeout for inactivity on a write since the uart timeout
doesn't start until a character is received, so you might have another
timeout that waits for the other side to send you a packet, and if the
byte count goes > 0 then you can cancel that timeout and use the UART
one to detect when the other side is done.