### PR TITLE
add tmr_set_period and change tmr_set_freq api (use floats)

### DIFF
--- a/hal/stm32f373/ppm.c
+++ b/hal/stm32f373/ppm.c
@@ -61,12 +61,12 @@ void ppm_set_phs(ppm_channel_t *ppm, float phs)
 	// turn phs into a ccr value
 	if (phs < 0.5)
 	{
-		ccr = ppm->tmr->period * 2 * phs - 1;
+		ccr = ppm->tmr->arr * 2 * phs - 1;
 		ppm->oc_cfg.TIM_OCPolarity = TIM_OCPolarity_High;
 	}
 	else
 	{
-		ccr = ppm->tmr->period * 2 * (phs - 0.5) - 1;
+		ccr = ppm->tmr->arr * 2 * (phs - 0.5) - 1;
 		ppm->oc_cfg.TIM_OCPolarity = TIM_OCPolarity_Low;
 	}
 	
@@ -128,7 +128,7 @@ void ppm_init(ppm_channel_t *ppm)
 	gpio_init_pin(ppm->pin);
 
 	// init ppm parent timer module (sets freq and phs via ppm_update_phs_on_freq_change cb)
-	tmr_set_freq_update_cb(ppm->tmr, ppm_update_phs_on_freq_change, ppm->ch, ppm);
+	tmr_set_timebase_update_cb(ppm->tmr, ppm_update_phs_on_freq_change, ppm->ch, ppm);
 	ppm->tmr->freq = ppm->freq * 2; // double frequency since we use toggle magic to make this work which needs freq*2 to the timer
 	tmr_init(ppm->tmr);
 }

--- a/hal/stm32f373/pwm.c
+++ b/hal/stm32f373/pwm.c
@@ -69,10 +69,10 @@ void pwm_set_duty(pwm_channel_t *pwm, float duty)
 	switch (pwm->oc_cfg.TIM_OCMode)
 	{
 		case TIM_OCMode_PWM1:
-			ccr = round(pwm->tmr->period * duty);
+			ccr = round(pwm->tmr->arr * duty);
 			break;
 		case TIM_OCMode_PWM2:
-			ccr = round(pwm->tmr->period * (1 - duty));
+			ccr = round(pwm->tmr->arr * (1 - duty));
 			break;
 		default:
 			///@todo error invalid mode
@@ -135,7 +135,7 @@ void pwm_init(pwm_channel_t *pwm)
 	gpio_init_pin(pwm->pin);
 
 	// init pwm parent timer module (sets freq and duty via pwm_update_duty_on_freq_change cb)
-	tmr_set_freq_update_cb(pwm->tmr, pwm_update_duty_on_freq_change, pwm->ch, pwm);
+	tmr_set_timebase_update_cb(pwm->tmr, pwm_update_duty_on_freq_change, pwm->ch, pwm);
 	tmr_init(pwm->tmr);
 }
 

--- a/hal/stm32f373/tmr.h
+++ b/hal/stm32f373/tmr.h
@@ -51,24 +51,34 @@ void tmr_reset(tmr_t *tmr);
 
 
 /**
- * @brief change the tmr frequency
+ * @brief change the tmr period
+ * @param tmr the timer to change the period of
+ * @param period new period in seconds
+ * @note this change effects the whole timer !
+ * @return actual period found in seconds
+ */
+float tmr_set_period(tmr_t *tmr, float period);
+
+
+/**
+ * @brief change the tmr frequency (aka 1/period)
  * @param tmr the timer to change the frequency of
  * @param freq new frequency in hz
  * @note this change effects the whole timer !
  * @return actual frequency found in Hz
  */
-uint32_t tmr_set_freq(tmr_t *tmr, uint32_t freq);
+float tmr_set_freq(tmr_t *tmr, float freq);
 
 
 /**
- * @brief add callback to run for each channel when this timer changes its frequency
+ * @brief add callback to run for each channel when this timer changes its timebase
  * @param tmr timer to connect the callback
  * @param cb callback function
  * @param channel indicates which channel on the timer this is called for
  * @param param callback parameter
  */
-typedef void (*freq_update_cb_t)(tmr_t *tmr, int ch, void *param); // internal callback for pwm/ppm modules etc
-void tmr_set_freq_update_cb(tmr_t *tmr, freq_update_cb_t cb, int channel, void *param); // internal function only
+typedef void (*timebase_update_cb_t)(tmr_t *tmr, int ch, void *param); // internal callback for pwm/ppm modules etc
+void tmr_set_timebase_update_cb(tmr_t *tmr, timebase_update_cb_t cb, int channel, void *param); // internal function only
 
 
 /**

--- a/hal/stm32f373/tmr_hw.h
+++ b/hal/stm32f373/tmr_hw.h
@@ -22,8 +22,9 @@ struct tmr_t
 {
 	TIM_TypeDef *tim;				///< which timer do you want to use
 
-	uint32_t freq;
-	uint32_t period;
+	float period;	// initial period of the tmr (set either period xor freq)
+	float freq;		// "
+	uint32_t arr;
 	TIM_TimeBaseInitTypeDef cfg;
 	uint8_t stop_on_halt;
 
@@ -35,8 +36,8 @@ struct tmr_t
 		uint16_t input_trigger;		// see TIM_Internal_Trigger_Selection (table 45 in reference manual)
 	} sync;
 
-	freq_update_cb_t freq_update_cb[4];
-	void *freq_update_cb_param[4];
+	timebase_update_cb_t timebase_update_cb[4];
+	void *timebase_update_cb_param[4];
 
 	tmr_update_cb_t update_cb;
 	void *update_cb_param;


### PR DESCRIPTION
this adds a new `tmr_set_period` function to the tmr module api, this is
almost the same as setting the frequency was using `tmr_set_freq`, but
this uses a floating point api for the period so we can achieve a wider
range of periods (from several minutes to ~28ns)

since this is the same as the `tmr_set_freq` function, but better I also
changed the `tmr_set_freq` call to accept a float for the frequency
rather than a uint32_t so both are symmetrical (the units are still in
Hz so when the code is recompiles it should just be up cast and it
should just work without any changes to the code required)