### PR TITLE
add pre-emption priority to hw definitions

### DIFF
--- a/hal/stm32f373/dma.c
+++ b/hal/stm32f373/dma.c
@@ -331,7 +331,7 @@ void dma_init(dma_t *dma)
 
 	// enable nvic
 	NVIC_InitStructure.NVIC_IRQChannel = dma_irq(dma);
-	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0;
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = dma->preemption_priority;
 	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
 	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&NVIC_InitStructure);

--- a/hal/stm32f373/dma_hw.h
+++ b/hal/stm32f373/dma_hw.h
@@ -34,6 +34,7 @@ struct dma_t
 {
 	DMA_Channel_TypeDef *channel;
 	struct dma_request_t *reqs;
+	uint8_t preemption_priority;
 };
 
 #endif

--- a/hal/stm32f373/gpio.c
+++ b/hal/stm32f373/gpio.c
@@ -372,7 +372,7 @@ static void gpio_set_edge_event(gpio_pin_t *pin, EXTITrigger_TypeDef trig, gpio_
 	// Enable and set EXTI9_5 Interrupt to the lowest priority
 	save_pin_for_irq(pin);  ///@todo this may need to warn if another pin is registered with this irq in case the caller forgets the pins share irq's
 	nvic_init.NVIC_IRQChannel = gpio_pin_to_exti_irq(pin);
-	nvic_init.NVIC_IRQChannelPreemptionPriority = 0x0F;
+	nvic_init.NVIC_IRQChannelPreemptionPriority = pin->preemption_priority;
 	nvic_init.NVIC_IRQChannelSubPriority = 0x0F;
 	nvic_init.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&nvic_init);

--- a/hal/stm32f373/gpio_hw.h
+++ b/hal/stm32f373/gpio_hw.h
@@ -26,6 +26,7 @@ struct gpio_pin_t
 	void *rising_cb_param;          ///< passed to rising cb
 	gpio_edge_event falling_cb;     ///< if not NULL thane called on falling edge
 	void *falling_cb_param;         ///< passed to falling cb
+	uint8_t preemption_priority;    ///< lower is a higher priority
 };
 
 

--- a/hal/stm32f373/spim.c
+++ b/hal/stm32f373/spim.c
@@ -272,7 +272,7 @@ void spim_init(spim_t *spim)
 	// setup the spim isr
 	nvic_init.NVIC_IRQChannelCmd = ENABLE;
 	nvic_init.NVIC_IRQChannel = spim_irq(spim);
-	nvic_init.NVIC_IRQChannelPreemptionPriority = 1;
+	nvic_init.NVIC_IRQChannelPreemptionPriority = spim->preemption_priority;
 	nvic_init.NVIC_IRQChannelSubPriority = 0;
 	nvic_init.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&nvic_init);

--- a/hal/stm32f373/spim_hw.h
+++ b/hal/stm32f373/spim_hw.h
@@ -27,6 +27,7 @@ struct spim_t
 {
 	SPI_TypeDef *channel;
 	uint16_t idle_address;							///< address to select when the bus is idle
+	uint8_t preemption_priority;
 
 	// device pins
 	gpio_pin_t **nss;								///< null terminated array of address pin where the first item is the LSB and the last is the MSB in the address .. to use HW controlled NSS set st_opts.SPI_NSS = SPI_NSS_Hard and this to NULL

--- a/hal/stm32f373/spis.c
+++ b/hal/stm32f373/spis.c
@@ -149,7 +149,7 @@ void spis_init(spis_t *spis)
 	// setup the spis isr
 	nvic_init.NVIC_IRQChannelCmd = ENABLE;
 	nvic_init.NVIC_IRQChannel = spis_irq(spis);
-	nvic_init.NVIC_IRQChannelPreemptionPriority = 1;
+	nvic_init.NVIC_IRQChannelPreemptionPriority = spis->preemption_priority;
 	nvic_init.NVIC_IRQChannelSubPriority = 0;
 	nvic_init.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&nvic_init);

--- a/hal/stm32f373/spis_hw.h
+++ b/hal/stm32f373/spis_hw.h
@@ -22,6 +22,7 @@ struct spis_t
 {
 	SPI_TypeDef *channel;
 	SPI_InitTypeDef st_spi_init;					///< details of how the spis should run (not all options are supported yet)
+	uint8_t preemption_priority;
 
 	// device pins
 	gpio_pin_t *nss, *sck, *miso, *mosi;

--- a/hal/stm32f373/tmr.c
+++ b/hal/stm32f373/tmr.c
@@ -357,7 +357,7 @@ void tmr_init(tmr_t *tmr)
 	// setup the tmr isr
 	nvic_init.NVIC_IRQChannelCmd = ENABLE;
 	nvic_init.NVIC_IRQChannel = tmr_irq(tmr);
-	nvic_init.NVIC_IRQChannelPreemptionPriority = 1;
+	nvic_init.NVIC_IRQChannelPreemptionPriority = tmr->preemption_priority;
 	nvic_init.NVIC_IRQChannelSubPriority = 0;
 	nvic_init.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&nvic_init);

--- a/hal/stm32f373/tmr_hw.h
+++ b/hal/stm32f373/tmr_hw.h
@@ -27,6 +27,7 @@ struct tmr_t
 	uint32_t arr;
 	TIM_TimeBaseInitTypeDef cfg;
 	uint8_t stop_on_halt;
+	uint8_t preemption_priority;
 
 	struct
 	{

--- a/hal/stm32f373/uart.c
+++ b/hal/stm32f373/uart.c
@@ -424,7 +424,7 @@ void uart_init(uart_t *uart)
 	// setup the uart isr
 	nvic_init.NVIC_IRQChannelCmd = ENABLE;
 	nvic_init.NVIC_IRQChannel = uart_irq(uart);
-	nvic_init.NVIC_IRQChannelPreemptionPriority = 1;
+	nvic_init.NVIC_IRQChannelPreemptionPriority = uart->preemption_priority;
 	nvic_init.NVIC_IRQChannelSubPriority = 0;
 	nvic_init.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&nvic_init);

--- a/hal/stm32f373/uart_hw.h
+++ b/hal/stm32f373/uart_hw.h
@@ -23,6 +23,7 @@ struct uart_t
 	USART_TypeDef *channel;					 	///< uart channel, ie USART1..USART3, 
 	gpio_pin_t *rx, *tx;						///< uart pins
 	USART_InitTypeDef cfg;						///< uart config (baudrate etc)
+	uint8_t preemption_priority;				///< set the pre-emption priority for uart interrupts
 
 	// read buffers
 	void *read_buf;								///< buffer to store the read results in


### PR DESCRIPTION
up unit now we had hardcoded the priority in the driver, but that is not
very flexible so now it is part of the hw.c definition so different
apps can choose different priorities for their peripherals ... the down
side to all this is that the apps all now must define these clearly or
they will default to 0 which is the highest priority (possibly not
desirable as it makes it hard to introduce a higher priority later, but
this is just the way the STM32 and C initialisers work unfortunately)