### PR TITLE
allow the gpio to be set to 'z' (ie floating)

### DIFF
--- a/hal/stm32f373/gpio.h
+++ b/hal/stm32f373/gpio.h
@@ -58,7 +58,7 @@ void gpio_set_falling_edge_event(gpio_pin_t *pin, gpio_edge_event cb, void *para
  * @param pin the pin from gpio_init_pin to set the value for
  * @param state set pin hi (1) or lo (0)
  */
-void gpio_set_pin(gpio_pin_t *pin, bool state);
+void gpio_set_pin(gpio_pin_t *pin, uint8_t state);
 
 
 /**

--- a/hal/stm32f373/gpio_hw.h
+++ b/hal/stm32f373/gpio_hw.h
@@ -27,6 +27,7 @@ struct gpio_pin_t
 	gpio_edge_event falling_cb;     ///< if not NULL thane called on falling edge
 	void *falling_cb_param;         ///< passed to falling cb
 	uint8_t preemption_priority;    ///< lower is a higher priority
+	uint8_t pos;
 };
 
 

--- a/utest/gpio/gpio_utest.c
+++ b/utest/gpio/gpio_utest.c
@@ -41,6 +41,7 @@ void init(void)
 	gpio_init_pin(&gpio_led2);
 	gpio_init_pin(&gpio_led3);
 	gpio_init_pin(&gpio_in);
+	gpio_init_pin(&gpio_tri_state);
 
 	gpio_set_falling_edge_event(&gpio_in, falling_edge, NULL);
 	gpio_set_rising_edge_event(&gpio_in, rising_edge, NULL);
@@ -50,6 +51,7 @@ int main(void)
 {
 	volatile bool pa_in_state unused;
 	int k;
+	uint8_t tri_state = 1;
 
 	init();
 
@@ -79,7 +81,24 @@ int main(void)
 				{}
 			}
 		}
+
+		// test input
 		pa_in_state = gpio_get_pin(&gpio_in);
+
+		// test tri state outputs by making a 3 level ramp
+		switch (tri_state)
+		{
+			case 0:
+				tri_state = 'z';
+				break;
+			case 'z':
+				tri_state = 1;
+				break;
+			case 1:
+				tri_state = 0;
+				break;
+		}
+		gpio_set_pin(&gpio_tri_state, tri_state);
 	}
 
 	return 0;

--- a/utest/gpio/hw.c
+++ b/utest/gpio/hw.c
@@ -31,4 +31,5 @@ gpio_pin_t gpio_led0		= {GPIOC, {GPIO_Pin_0,  GPIO_Mode_OUT, GPIO_Speed_50MHz, G
 gpio_pin_t gpio_led1		= {GPIOC, {GPIO_Pin_1,  GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL}};
 gpio_pin_t gpio_led2		= {GPIOC, {GPIO_Pin_2,  GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL}};
 gpio_pin_t gpio_led3		= {GPIOC, {GPIO_Pin_3,  GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL}};
+gpio_pin_t gpio_tri_state	= {GPIOA, {GPIO_Pin_3,  GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL}};
 #endif

--- a/utest/gpio/hw.h
+++ b/utest/gpio/hw.h
@@ -23,6 +23,7 @@ extern gpio_pin_t gpio_led0;
 extern gpio_pin_t gpio_led1;
 extern gpio_pin_t gpio_led2;
 extern gpio_pin_t gpio_led3;
+extern gpio_pin_t gpio_tri_state;
 
 #endif
 


### PR DESCRIPTION
this allows any gpio pin to be set to logic 0 (lo), 1 (high) or 'z'
(floating) on the stm32f373 ... to do this the pin is put into input
mode which will float the output (note to see it float you should NOT
enable the pull-up/downs, otherwise these pull-up/downs will set the
output state (albeit quite weakly)