### PR TITLE
add command to reset the UART

### DIFF
--- a/hal/stm32f373/uart.c
+++ b/hal/stm32f373/uart.c
@@ -399,6 +399,13 @@ void uart_cancel_write(uart_t *uart)
 }
 
 
+void uart_reset(uart_t *uart)
+{
+	USART_Cmd(uart->channel, DISABLE);
+	USART_Cmd(uart->channel, ENABLE);
+}
+
+
 void uart_init(uart_t *uart)
 {
 	NVIC_InitTypeDef nvic_init;

--- a/hal/stm32f373/uart.h
+++ b/hal/stm32f373/uart.h
@@ -98,6 +98,13 @@ int uart_read_count(uart_t *uart);
 
 
 /**
+ * @brief reset the whole uart
+ * @param uart uart device being reset
+ */
+void uart_reset(uart_t *uart);
+
+
+/**
  * @brief cancel uart read
  * @param uart uart device to cancel read on
  */


### PR DESCRIPTION
this is mainly useful as I cannot find a way to reset the RTO other than
resetting the whole UART ... but I cannot hide this inside the uart
module as the tx and rx are asynchronous and if I reset it before a read
I might ruin a write and visa versa ... so the end user will need to
reset the UART when they come to a point where both the tx and rx are
free