### PR TITLE
fix some issue found on the stm32f4 port

### DIFF
--- a/hal/stm32f4/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0/Libraries/CMSIS/Device/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c
+++ b/hal/stm32f4/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0/Libraries/CMSIS/Device/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c
@@ -514,10 +514,12 @@ void SystemInit(void)
   SetSysClock();
 
   /* Configure the Vector Table location add offset address ------------------*/
+#ifdef SET_VECT_TAB_SRC
 #ifdef VECT_TAB_SRAM
   SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
   SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+#endif
 #endif
 }
 

--- a/hal/stm32f4/bootstrap.h
+++ b/hal/stm32f4/bootstrap.h
@@ -14,9 +14,9 @@
 
 
 // describes a program the bootstrap can run
-///@todo this should be stm32f373 specific
+///@todo this should be stm32f4 specific
 #define BOOTSTRAP_PROG_HEADER 0x01
-#define BOOTSTRAP_PROG_HEADER_HW_ID 2 // make this a unique number for each HW type
+#define BOOTSTRAP_PROG_HEADER_HW_ID 3 // make this a unique number for each HW type
 packed_start
 packed(struct) bootstrap_prog_header
 {

--- a/hal/stm32f4/sys.c
+++ b/hal/stm32f4/sys.c
@@ -312,7 +312,7 @@ void sys_init(void)
 }
 
 
-//#ifdef USE_FULL_ASSERT
+#ifdef USE_FULL_ASSERT
 /**
  * @brief report the file and line where the assert failed and spin
  * @param  file pointer to the source file name
@@ -325,7 +325,7 @@ void assert_failed(uint8_t* file, uint32_t line)
 	{}
 }
 
-//#endif
+#endif
 
 
 


### PR DESCRIPTION
fix vector table issue ... whoops I forgot to fix the default sys ini
that setups the stacks & basic clocks etc from clobbering the VTOR reg
.. that breaks our bootstrap meaning no ISR's were working if we load
through the bootstrap !!!

use unique BOOTSTRAP_PROG_HEADER_HW_ID, this was copied from the
stm32f373 so it was not unique and the bootloader could not tell the
different archs apart and would allow booting/bootloading incorrect
firmware

disable the FULL_ASSERT, that was just for dev but in prod we assume the
mos works and does not need all that overhead