### PR TITLE
fix up pwm api to make it more like the parent timer api

### DIFF
--- a/hal/stm32f373/pwm.c
+++ b/hal/stm32f373/pwm.c
@@ -112,7 +112,7 @@ void pwm_set_duty(pwm_channel_t *pwm, float duty)
 }
 
 
-uint32_t pwm_set_freq(pwm_channel_t *pwm, uint32_t freq)
+float pwm_set_freq(pwm_channel_t *pwm, float freq)
 {
 	freq = tmr_set_freq(pwm->tmr, freq);
 	// note the duty will be updated from the pwm_update_duty_on_freq_change below by the tmr
@@ -126,6 +126,12 @@ static void pwm_update_duty_on_freq_change(tmr_t *tmr, int ch, void *param)
 
 	// update this channels duty for the new timer freq
 	pwm_set_duty(pwm, pwm->duty);
+}
+
+
+void pwm_sync_cfg(pwm_channel_t *pwm, uint8_t ext_clk_mode, uint8_t sync_mode)
+{
+	return tmr_sync_cfg(pwm->tmr, ext_clk_mode, sync_mode);
 }
 
 

--- a/hal/stm32f373/pwm.h
+++ b/hal/stm32f373/pwm.h
@@ -50,7 +50,7 @@ void pwm_reset(pwm_channel_t *pwm);
  * @note this change effects the whole timer !
  * @return actual frequency found in Hz
  */
-uint32_t pwm_set_freq(pwm_channel_t *pwm, uint32_t freq);
+float pwm_set_freq(pwm_channel_t *pwm, float freq);
 
 
 /**
@@ -60,6 +60,15 @@ uint32_t pwm_set_freq(pwm_channel_t *pwm, uint32_t freq);
  */
 void pwm_set_duty(pwm_channel_t *pwm, float duty);
 
+
+/**
+ * @brief setup the pwm timer sync
+ * @see tmr_sync_cfg
+ * @param pwm the pwm associated with timer to setup the sync on
+ * @param ext_clk_mode 0 means timer is clocked from internal clock, 1 means external clock (see ext_clk_freq)
+ * @param sync_mode if sync mode is 0 run like a normal timer, otherwise use the slave_mode for sync
+ */
+void pwm_sync_cfg(pwm_channel_t *pwm, uint8_t ext_clk_mode, uint8_t sync_mode);
 
 
 /**

--- a/hal/stm32f4/pwm.c
+++ b/hal/stm32f4/pwm.c
@@ -112,7 +112,7 @@ void pwm_set_duty(pwm_channel_t *pwm, float duty)
 }
 
 
-uint32_t pwm_set_freq(pwm_channel_t *pwm, uint32_t freq)
+float pwm_set_freq(pwm_channel_t *pwm, float freq)
 {
 	freq = tmr_set_freq(pwm->tmr, freq);
 	// note the duty will be updated from the pwm_update_duty_on_freq_change below by the tmr
@@ -126,6 +126,12 @@ static void pwm_update_duty_on_freq_change(tmr_t *tmr, int ch, void *param)
 
 	// update this channels duty for the new timer freq
 	pwm_set_duty(pwm, pwm->duty);
+}
+
+
+void pwm_sync_cfg(pwm_channel_t *pwm, uint8_t ext_clk_mode, uint8_t sync_mode)
+{
+	return tmr_sync_cfg(pwm->tmr, ext_clk_mode, sync_mode);
 }
 
 

--- a/hal/stm32f4/pwm.h
+++ b/hal/stm32f4/pwm.h
@@ -50,7 +50,7 @@ void pwm_reset(pwm_channel_t *pwm);
  * @note this change effects the whole timer !
  * @return actual frequency found in Hz
  */
-uint32_t pwm_set_freq(pwm_channel_t *pwm, uint32_t freq);
+float pwm_set_freq(pwm_channel_t *pwm, float freq);
 
 
 /**
@@ -60,6 +60,15 @@ uint32_t pwm_set_freq(pwm_channel_t *pwm, uint32_t freq);
  */
 void pwm_set_duty(pwm_channel_t *pwm, float duty);
 
+
+/**
+ * @brief setup the pwm timer sync
+ * @see tmr_sync_cfg
+ * @param pwm the pwm associated with timer to setup the sync on
+ * @param ext_clk_mode 0 means timer is clocked from internal clock, 1 means external clock (see ext_clk_freq)
+ * @param sync_mode if sync mode is 0 run like a normal timer, otherwise use the slave_mode for sync
+ */
+void pwm_sync_cfg(pwm_channel_t *pwm, uint8_t ext_clk_mode, uint8_t sync_mode);
 
 
 /**


### PR DESCRIPTION
pwm frequency should be a float since it is a float in the parent timer

add pwm sync shortcut api to call tmr_sync_cfg on its parent timer (this
is just convenient so the tmr can remain opaque to the caller)