### PR TITLE
fix up some issues with the stm32f4 adc

### DIFF
--- a/hal/stm32f4/adc.h
+++ b/hal/stm32f4/adc.h
@@ -28,8 +28,8 @@ typedef struct adc_channel_t adc_channel_t;
  * @param cb call this once count samples have been read into dst
  * @param param pass this to cb on completion
  */
-typedef void (*adc_trace_complete_t)(adc_channel_t *ch, volatile int16_t *dst, int count, void *param);
-void adc_trace(adc_channel_t *ch, volatile int16_t *dst, int count, int trigger, adc_trace_complete_t cb, void *param);
+typedef void (*adc_trace_complete_t)(adc_channel_t *ch, uint16_t *dst, int count, void *param);
+void adc_trace(adc_channel_t *ch, uint16_t *dst, int count, int trigger, adc_trace_complete_t cb, void *param);
 
 
 /**

--- a/hal/stm32f4/adc_hw.h
+++ b/hal/stm32f4/adc_hw.h
@@ -49,7 +49,7 @@ struct adc_channel_t
 
 	adc_trace_complete_t complete;
 	void *complete_param;
-	volatile int16_t *buf;
+	uint16_t *buf;
 	int count;
 };
 

--- a/utest/adc/adc_utest.c
+++ b/utest/adc/adc_utest.c
@@ -14,40 +14,29 @@
 #include <string.h>
 #include <hal.h>
 
-volatile uint16_t buf[4096];
-volatile uint32_t val = 0;
-
-volatile void *vmemset(volatile void *s, int8_t c, size_t n)
-{
-	volatile unsigned char *p = s;
-	while (n--)
-		*p++ = (unsigned char)c;
-	return s;
-}
+adc_trace_point_t buf[4096];
+uint32_t val = 0;
 
 void init(void)
 {
 	sys_init();
 	adc_channel_init(adc_chan);
-	vmemset(buf, 0x00, sizeof(buf));
+	memset((void *)buf, 0x00, sizeof(buf));
 }
 
-void adc_handle_buffer(volatile uint16_t *dst, int len)
+void adc_handle_buffer(adc_trace_point_t *dst, int len)
 {
 	sys_nop();
 }
 
-void adc_complete(adc_channel_t *ch, volatile int16_t *dst, int len, void *param)
+void adc_complete(adc_channel_t *ch, adc_trace_point_t *dst, int len, void *param)
 {
-	int n;
-	for (n=0; n < len; n++)
-		buf[n] += 32767;
-
 	val = adc_read(ch);
-	adc_handle_buffer((volatile uint16_t *)dst, len);
+	adc_handle_buffer((adc_trace_point_t *)dst, len);
 
-	vmemset(buf, 0x00, sizeof(buf));
-	adc_trace(ch, (volatile int16_t *)buf, sizeof(buf)/sizeof(uint16_t), 0, adc_complete, param);
+	memset((void *)buf, 0x00, sizeof(buf));
+	val = adc_read(ch);
+	adc_trace(ch, (adc_trace_point_t *)buf, sizeof(buf)/sizeof(adc_trace_point_t), 0, adc_complete, param);
 }
 
 int main(void)
@@ -55,7 +44,7 @@ int main(void)
 	init();
 
 	val = adc_read(adc_chan);
-	adc_trace(adc_chan, (volatile int16_t *)buf, sizeof(buf)/sizeof(uint16_t), 0, adc_complete, NULL);
+	adc_trace(adc_chan, (adc_trace_point_t *)buf, sizeof(buf)/sizeof(adc_trace_point_t), 0, adc_complete, NULL);
 	while (1)
 	{}
 

--- a/utest/adc/hw.h
+++ b/utest/adc/hw.h
@@ -16,5 +16,12 @@
 
 extern adc_channel_t *adc_chan;
 
+
+#ifdef STM32F37X
+typedef volatile int16_t adc_trace_point_t;
+#else
+typedef uint16_t adc_trace_point_t;
+#endif
+
 #endif
 


### PR DESCRIPTION
this is a single ended adc so the results should be uint16_t as the
results are not proper 2's complement encoded (the caller will have to
adapt their code between this and the int16_t)

fix OVR issue that stops further adc reads/trace calls because the DDS
bit is set ... we set this to support circ mode, but a side effect is
this causes overruns [OVR] owing to continued DMA requests ... when we
go to make another ADC because the OVR bit is set nothing happens as the
hardware is waiting for us to clear this ... as a fix for now we just
clear the OVR flag in the trace complete event