### PR TITLE
fix gpio_set_pin call before gpio_init_pin corrupts other pin configs

### DIFF
--- a/hal/stm32f373/gpio.c
+++ b/hal/stm32f373/gpio.c
@@ -409,6 +409,8 @@ void gpio_init_pin(gpio_pin_t *pin)
 			break;
 		}
 	}
+
+	pin->initialised = 1;
 }
 
 
@@ -459,13 +461,13 @@ void gpio_set_pin(gpio_pin_t *pin, uint8_t state)
 		case 'Z':
 		case 'z':
 			// set the pin to floating by switching to an input
-			if (moder != GPIO_Mode_IN)
+			if (moder != GPIO_Mode_IN && pin->initialised)
 				pin->port->MODER &= ~(GPIO_MODER_MODER0 << 2*pin->pos);
 			break;
 		case 1:
 			// set hi & ensure we are configured as a output
 			pin->port->BSRR = pin->cfg.GPIO_Pin;
-			if (moder != GPIO_Mode_OUT)
+			if (moder != GPIO_Mode_OUT && pin->initialised)
 			{
 				pin->port->MODER &= ~(GPIO_MODER_MODER0 << 2*pin->pos);
 				pin->port->MODER |= GPIO_Mode_OUT << 2*pin->pos;
@@ -475,7 +477,7 @@ void gpio_set_pin(gpio_pin_t *pin, uint8_t state)
 		default:
 			// set lo & ensure we are configured as a output
 			pin->port->BRR = pin->cfg.GPIO_Pin;
-			if (moder != GPIO_Mode_OUT)
+			if (moder != GPIO_Mode_OUT && pin->initialised)
 			{
 				pin->port->MODER &= ~(GPIO_MODER_MODER0 << 2*pin->pos);
 				pin->port->MODER |= GPIO_Mode_OUT << 2*pin->pos;

--- a/hal/stm32f373/gpio_hw.h
+++ b/hal/stm32f373/gpio_hw.h
@@ -28,6 +28,7 @@ struct gpio_pin_t
 	void *falling_cb_param;         ///< passed to falling cb
 	uint8_t preemption_priority;    ///< lower is a higher priority
 	uint8_t pos;
+	uint8_t initialised;
 };
 
 

--- a/hal/stm32f4/gpio.c
+++ b/hal/stm32f4/gpio.c
@@ -408,6 +408,8 @@ void gpio_init_pin(gpio_pin_t *pin)
 			break;
 		}
 	}
+
+	pin->initialised = 1;
 }
 
 
@@ -458,13 +460,13 @@ void gpio_set_pin(gpio_pin_t *pin, uint8_t state)
 		case 'Z':
 		case 'z':
 			// set the pin to floating by switching to an input
-			if (moder != GPIO_Mode_IN)
+			if (moder != GPIO_Mode_IN && pin->initialised)
 				pin->port->MODER &= ~(GPIO_MODER_MODER0 << 2*pin->pos);
 			break;
 		case 1:
 			// set hi & ensure we are configured as a output
 			pin->port->BSRRL = (uint16_t)(pin->cfg.GPIO_Pin & 0xffff);
-			if (moder != GPIO_Mode_OUT)
+			if (moder != GPIO_Mode_OUT && pin->initialised)
 			{
 				pin->port->MODER &= ~(GPIO_MODER_MODER0 << 2*pin->pos);
 				pin->port->MODER |= GPIO_Mode_OUT << 2*pin->pos;
@@ -474,7 +476,7 @@ void gpio_set_pin(gpio_pin_t *pin, uint8_t state)
 		default:
 			// set lo & ensure we are configured as a output
 			pin->port->BSRRH = (uint16_t)(pin->cfg.GPIO_Pin & 0xffff);
-			if (moder != GPIO_Mode_OUT)
+			if (moder != GPIO_Mode_OUT && pin->initialised)
 			{
 				pin->port->MODER &= ~(GPIO_MODER_MODER0 << 2*pin->pos);
 				pin->port->MODER |= GPIO_Mode_OUT << 2*pin->pos;

--- a/hal/stm32f4/gpio_hw.h
+++ b/hal/stm32f4/gpio_hw.h
@@ -28,6 +28,7 @@ struct gpio_pin_t
 	void *falling_cb_param;         ///< passed to falling cb
 	uint8_t preemption_priority;    ///< lower is a higher priority
 	uint8_t pos;
+	uint8_t initialised;
 };
 
 


### PR DESCRIPTION
sometimes we want to call gpio_set_pin before the gpio_init_pin so that
we pre-program the pin value so we dont get a weird edge event between
gpio_pin_init and gpio_pin_set (a better way would be to add a initial
pin state to the gpio_init_pin but this would break a lot of things in a
lot of existing code) .... however since we added the 'z' options to
tri-state the gpio line we rely on the pin->pos variable when we set the
MODER reg on the stm32f3|4, but if gpio_init is not run yet this is just
0 (as this value needs to be determined at runtime ) and we will change
the MODER of possibly some other pins !!

to fix this I still set the value to 0 or 1 using the BSRRL/BSSRH regs
on the gpio_set_pin, even if gpio_init has not run (so the pin will
still be set hi/lo, just not 'z') ... but I check to ensure the
gpio_init_pin has run (ie pin->initialised == 1) before setting the
MODER reg ... this allows the functionality we want except you cannot
set the mode to 'z' on init, which is not so bad