### PR TITLE
whoops some typos in the erase cmd

### DIFF
--- a/hal/stm32f373/stm32f373.mk
+++ b/hal/stm32f373/stm32f373.mk
@@ -50,7 +50,7 @@ OPENOCD_ERASE_CMDS = ''
 OPENOCD_ERASE_CMDS += -c 'reset halt'
 OPENOCD_ERASE_CMDS += -c 'sleep 10'
 OPENOCD_ERASE_CMDS += -c 'sleep 10'
-OPENOCD_FLASH_CMDS += -c 'stm32f1x unlock 0'
+OPENOCD_ERASE_CMDS += -c 'stm32f1x unlock 0'
 OPENOCD_ERASE_CMDS += -c 'stm32f1x mass_erase 0'
 OPENOCD_ERASE_CMDS += -c shutdown
 export OPENOCD_ERASE_CMDS

--- a/hal/stm32f4/stm32f4.mk
+++ b/hal/stm32f4/stm32f4.mk
@@ -50,7 +50,7 @@ OPENOCD_ERASE_CMDS = ''
 OPENOCD_ERASE_CMDS += -c 'reset halt'
 OPENOCD_ERASE_CMDS += -c 'sleep 10'
 OPENOCD_ERASE_CMDS += -c 'sleep 10'
-OPENOCD_FLASH_CMDS += -c 'stm32f4x unlock 0'
+OPENOCD_ERASE_CMDS += -c 'stm32f4x unlock 0'
 OPENOCD_ERASE_CMDS += -c 'stm32f4x mass_erase 0'
 OPENOCD_ERASE_CMDS += -c shutdown
 export OPENOCD_ERASE_CMDS


### PR DESCRIPTION
this just meant that the erase command was not running the unlock call
(which I think is not needed anyway if your erasing, I had it just be be
sure) ... but it does mean that the flash function was unlocking the
flash twice which is silly ... so this just fixes that stuff :)