### PR TITLE
fix bug in timer sync routine

### DIFF
--- a/hal/stm32f373/tmr.c
+++ b/hal/stm32f373/tmr.c
@@ -217,7 +217,6 @@ void tmr_sync_cfg(struct tmr_t *tmr, uint8_t ext_clk_mode, uint8_t sync_mode)
 	tmr->sync.ext_clk_mode = ext_clk_mode;
 
 	TIM_SelectSlaveMode(tmr->tim, slave_mode); // set SMS bits
-	tmr->sync.slave_mode = slave_mode;
 }
 
 

--- a/hal/stm32f4/tmr.c
+++ b/hal/stm32f4/tmr.c
@@ -154,7 +154,6 @@ void tmr_sync_cfg(struct tmr_t *tmr, uint8_t ext_clk_mode, uint8_t sync_mode)
 	tmr->sync.ext_clk_mode = ext_clk_mode;
 
 	TIM_SelectSlaveMode(tmr->tim, slave_mode); // set SMS bits
-	tmr->sync.slave_mode = slave_mode;
 }
 
 


### PR DESCRIPTION
do not overwrite the slave_mode setup in hw.c as we need to reinstate
this when the sync mode is reactivated