### PR TITLE
fix gpio_init_pin (again)

### DIFF
--- a/hal/stm32f4/gpio.c
+++ b/hal/stm32f4/gpio.c
@@ -379,8 +379,6 @@ static void gpio_set_edge_event(gpio_pin_t *pin, EXTITrigger_TypeDef trig, gpio_
 }
 
 
-
-
 void gpio_init_pin(gpio_pin_t *pin)
 {
 	uint8_t pinpos;
@@ -393,11 +391,6 @@ void gpio_init_pin(gpio_pin_t *pin)
 	RCC_AHB1PeriphClockCmd(pin_to_rcc_periph(pin), ENABLE);
 	RCC_AHB1PeriphResetCmd(pin_to_rcc_periph(pin), DISABLE);
 
-	// setup the pin configurations
-	if (pin->cfg.GPIO_Mode == GPIO_Mode_AF)
-		GPIO_PinAFConfig(pin->port, gpio_pin_to_pin_source(pin), pin->af);
-	GPIO_Init(pin->port, &pin->cfg);
-
 	// find the position for this pin (yuk long lookups)
 	pin->pos = 255; // indicates an invalid pos (the GPIO_Pin is likely bad)
 	for (pinpos = 0x00; pinpos < 16; pinpos++)
@@ -405,11 +398,37 @@ void gpio_init_pin(gpio_pin_t *pin)
 		if (pin->cfg.GPIO_Pin == (1 << pinpos))
 		{
 			pin->pos = pinpos;
-			break;
+
+			// setup the pin configurations (mostly just copied from GPIO_Init, but modified to
+			// ensure we stay in 'z' state when returning from init and the user sets the initial
+			// value for an output by calling something like gpio_set_pin)
+			if (pin->cfg.GPIO_Mode == GPIO_Mode_AF)
+				GPIO_PinAFConfig(pin->port, gpio_pin_to_pin_source(pin), pin->af);
+
+			if ((pin->cfg.GPIO_Mode == GPIO_Mode_OUT) || (pin->cfg.GPIO_Mode == GPIO_Mode_AF))
+			{
+				// speed mode configuration
+				pin->port->OSPEEDR &= ~(GPIO_OSPEEDER_OSPEEDR0 << 2*pin->pos * 2);
+				pin->port->OSPEEDR |= ((uint32_t)(pin->cfg.GPIO_Speed) << (pin->pos * 2));
+
+				// output mode configuration
+				pin->port->OTYPER  &= ~((GPIO_OTYPER_OT_0) << ((uint16_t)pin->pos)) ;
+				pin->port->OTYPER |= (uint16_t)(((uint16_t)pin->cfg.GPIO_OType) << ((uint16_t)pin->pos));
+			}
+
+			// default to 'z' state after init
+			pin->port->MODER &= ~(GPIO_MODER_MODER0 << 2*pin->pos);
+
+			/* pull-up pull down resistor configuration*/
+			pin->port->PUPDR &= ~(GPIO_PUPDR_PUPDR0 << ((uint16_t)pin->pos * 2));
+			pin->port->PUPDR |= (((uint32_t)pin->cfg.GPIO_PuPd) << (pin->pos * 2));
+
+			pin->initialised = 1;
+			return;
 		}
 	}
 
-	pin->initialised = 1;
+	//@todo error we should never get to this code !!
 }
 
 

--- a/utest/gpio/hw.c
+++ b/utest/gpio/hw.c
@@ -40,7 +40,7 @@ gpio_pin_t gpio_tri_state	= {GPIOA, {GPIO_Pin_3,  GPIO_Mode_OUT, GPIO_Speed_50MH
 
 #include <stm32f4xx_conf.h>
 #include <gpio_hw.h>
-gpio_pin_t gpio_in 			= {GPIOA, {GPIO_Pin_5, GPIO_Mode_IN, GPIO_Speed_50MHz, 0, GPIO_PuPd_NOPULL}};
+gpio_pin_t gpio_in 			= {GPIOA, {GPIO_Pin_0,  GPIO_Mode_IN, GPIO_Speed_50MHz, 0, GPIO_PuPd_NOPULL}};
 gpio_pin_t gpio_led0		= {GPIOC, {GPIO_Pin_0,  GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL}};
 gpio_pin_t gpio_led1		= {GPIOC, {GPIO_Pin_1,  GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL}};
 gpio_pin_t gpio_led2		= {GPIOC, {GPIO_Pin_2,  GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL}};


### PR DESCRIPTION
back in commit d408ef41ca22ca I tried to fix an issue where calling
`gpio_set_pin` prior to `gpio_init_pin` caused memory leak like issue
... it turns out that the whole concept of calling `gpio_set_pin` prior
to `gpio_init_pin` to set the gpio initial state is flawed and does not
work because: 1) the peripheral clk is disabled (unless another
gpio_init enabled it earlier), thanks to @abor for finding this 2) the
STM library `GPIO_Init` will overwrite the MODER reg anyway

back in issue d408ef41ca22ca I was planning to make `gpio_init` accept a
initial value argument ... I have changed my mind because it make
initialisation of inputs confusing ... so instead I have changed the
code so that we don't call `GPIO_Init` from the ST libs anymore and I
init all the pins modes to inputs, ie 'z' state (but the output
speed/type etc are still set if it is configured in the hw.c as an
output) ... then the user will simply set the desired initial value with
a subsequent call to `gpio_set_pin` ... this has the benefit/draw-back
that existing code will compile without error, but since there is no
error we will not be actively made to fix existing bugs where we are
relying on the `gpio_set_pin` before a `gpio_init` to set the initial
value ... so if your using this code please revise your `gpio_init` code

also a snuck in and update to the gpio hw.c so as to make the button map
to a button on the stm32f429 discovery kit