### PR TITLE
fix adc trace with pending dma request fails

### DIFF
--- a/hal/stm32f373/adc.c
+++ b/hal/stm32f373/adc.c
@@ -178,6 +178,7 @@ void adc_trace(adc_channel_t *ch, volatile int16_t *dst, int count, int trigger,
 	if (adc->dma == NULL)
 		///@todo error current implementation does not support interrupts so we need a dma
 		return;
+	dma_cancel(adc->dma); // cancel any pending/running dma
 	adc->dma_req.complete = adc_dma_complete;
 	ch->buf = dst;
 	ch->count = count;

--- a/hal/stm32f4/adc.c
+++ b/hal/stm32f4/adc.c
@@ -169,6 +169,7 @@ void adc_trace(adc_channel_t *ch, uint16_t *dst, int count, int trigger, adc_tra
 	if (adc->dma == NULL)
 		///@todo error current implementation does not support interrupts so we need a dma
 		goto done;
+	dma_cancel(adc->dma); // cancel any pending/running dma
 	adc->dma_req.complete = adc_dma_complete;
 	ch->buf = dst;
 	ch->count = count;


### PR DESCRIPTION
if we try to start an adc trace before the last one finished then the
new trace is ignored and the old one takes precedence which is probably
not a very intuitive api ... so now I cancel the old DMA request and
make a new one