### PR TITLE
fix bug reporting the timer period wrong

### DIFF
--- a/hal/stm32f373/tmr.c
+++ b/hal/stm32f373/tmr.c
@@ -363,7 +363,7 @@ done:
 	tmr_set_timebase(tmr, MAX(arr - 1, 0), (uint16_t)CLIP(prescaler - 1, 0, UINT16_MAX));
 
 	// return the actual period used
-	return (float)(tmr->prescaler * tmr->arr) / (float)tmr_freq;
+	return (float)((tmr->prescaler + 1) * (tmr->arr + 1)) / (float)tmr_freq;
 }
 
 

--- a/hal/stm32f4/tmr.c
+++ b/hal/stm32f4/tmr.c
@@ -300,7 +300,7 @@ done:
 	tmr_set_timebase(tmr, MAX(arr - 1, 0), (uint16_t)CLIP(prescaler - 1, 0, UINT16_MAX));
 
 	// return the actual period used
-	return (float)(tmr->prescaler * tmr->arr) / (float)tmr_freq;
+	return (float)((tmr->prescaler + 1) * (tmr->arr + 1)) / (float)tmr_freq;
 }
 
 


### PR DESCRIPTION
we need to add the +1's back onto the prescaler and arr registers for
the calculations (whoops)