### PR TITLE
add option to cancel ADC trace

### DIFF
--- a/hal/stm32f373/adc.c
+++ b/hal/stm32f373/adc.c
@@ -227,6 +227,20 @@ void adc_trace(adc_channel_t *ch, volatile int16_t *dst, int count, int trigger,
 }
 
 
+void adc_cancel_trace(adc_channel_t *ch)
+{
+	adc_t *adc = ch->adc;
+
+	// cancel dma
+	sys_enter_critical_section();
+	if (adc->dma == NULL)
+		///@todo error current implementation does not support interrupts so we need a dma
+		return;
+	dma_cancel(adc->dma); // cancel any pending/running dma
+	sys_leave_critical_section();
+}
+
+
 int32_t adc_read(adc_channel_t *channel)
 {
 	int32_t r;

--- a/hal/stm32f373/adc.h
+++ b/hal/stm32f373/adc.h
@@ -33,6 +33,13 @@ void adc_trace(adc_channel_t *ch, volatile int16_t *dst, int count, int trigger,
 
 
 /**
+ * @brief cancel any pending trace above
+ * @param ch channel to cancel trace on
+ */
+void adc_cancel_trace(adc_channel_t *ch);
+
+
+/**
  * @brief read a single value from the adc channel
  * @param ch channel to read from
  */

--- a/hal/stm32f4/adc.c
+++ b/hal/stm32f4/adc.c
@@ -214,6 +214,20 @@ done:
 }
 
 
+void adc_cancel_trace(adc_channel_t *ch)
+{
+	adc_t *adc = ch->adc;
+
+	// cancel dma
+	sys_enter_critical_section();
+	if (adc->dma == NULL)
+		///@todo error current implementation does not support interrupts so we need a dma
+		return;
+	dma_cancel(adc->dma); // cancel any pending/running dma
+	sys_leave_critical_section();
+}
+
+
 int32_t adc_read(adc_channel_t *ch)
 {
 	int32_t ret;

--- a/hal/stm32f4/adc.h
+++ b/hal/stm32f4/adc.h
@@ -33,6 +33,13 @@ void adc_trace(adc_channel_t *ch, uint16_t *dst, int count, int trigger, adc_tra
 
 
 /**
+ * @brief cancel any pending trace above
+ * @param ch channel to cancel trace on
+ */
+void adc_cancel_trace(adc_channel_t *ch);
+
+
+/**
  * @brief read a single value from the adc channel
  * @param ch channel to read from
  */


### PR DESCRIPTION
if a trace is in progress/armed and waiting for a trigger this will
allow the caller to cancel the DMA request that "glues" the adc trace
together effectively canceling the trace allowing for another trace to
be scheduled or the adc_read function to be called on the adc channel