### PR TITLE
add sdram fmc module for stm32f4's featuring this peripheral

### DIFF
--- a/hal/stm32f4/Makefile
+++ b/hal/stm32f4/Makefile
@@ -46,6 +46,10 @@ SRC  = ./STM32F4xx_DSP_StdPeriph_Lib_V1.8.0/Libraries/CMSIS/Device/ST/STM32F4xx/
 	./spi.c \
 	./sys.c
 
+ifneq (,$(filter $(SUB_ARCH), STM32F427_437xx STM32F429_439xx STM32F446xx STM32F469_479xx))
+SRC += fmc.c
+endif
+
 	
 # these files are only included when configured ... this is because they implement isr's and gcc cannot 
 # know that you aren't going to call these so it includes everything, and this can blow your code size ...

--- a/hal/stm32f4/fmc.c
+++ b/hal/stm32f4/fmc.c
@@ -1,0 +1,149 @@
+/**
+ * @file fmc.c
+ *
+ * @brief implement the flexible memory controller module for the stm32f4
+ *
+ * @author OT
+ *
+ * @date June 2018
+ *
+ */
+
+
+#include <stm32f4xx_conf.h>
+#include "hal.h"
+#include "gpio_hw.h"
+#include "fmc_hw.h"
+
+
+static void init_gpio_pin_array(gpio_pin_t **pins, int len)
+{
+	int pi;
+	for (pi = 0; pi < len; pi++)
+	{
+		if (!pins[pi])
+			continue;
+		gpio_init_pin(pins[pi]);
+	}
+}
+
+
+static void fmc_sdram_cmd(uint8_t bank, uint32_t cmd, uint32_t autorefresh, uint32_t modereg)
+{
+	uint32_t sdcmr;
+
+	// set the target bank
+	switch (bank)
+	{
+		case 0:
+			sdcmr = FMC_SDCMR_CTB1;
+			break;
+		case 1:
+			sdcmr = FMC_SDCMR_CTB2;
+			break;
+		default:
+			sdcmr = FMC_SDCMR_CTB1 | FMC_SDCMR_CTB2; // both
+	}
+
+	// set the auto-reload bits
+	sdcmr |= ((autorefresh - 1) & 0x0f) << 5;
+
+	// set the mode register
+	sdcmr |= (modereg & 0x1fff) << 9;
+
+	// add the cmd
+	sdcmr |= (cmd & 0x7);
+
+	// wait for the controller to be free and issue command
+	while (FMC_Bank5_6->SDSR & FMC_SDSR_BUSY);
+	FMC_Bank5_6->SDCMR = sdcmr;
+}
+
+
+#define FORMAT_TIMING_REG(x,bit0) ((((uint32_t)x > 0) && ((uint32_t)x <= 16)? x - 1: ((uint32_t)x == 0)? 0: 15) << bit0)
+void fmc_sdram_init(fmc_sdram_t *sdram)
+{
+	uint32_t sdcr, sdtr;
+	uint32_t sdcr0, sdtr0;
+
+	// enable the fmc clk
+	RCC_AHB3PeriphClockCmd(RCC_AHB3Periph_FMC, ENABLE);
+
+	// init the gpio's
+	gpio_init_pin(sdram->clk);
+	init_gpio_pin_array(sdram->clk_en, 2);
+	init_gpio_pin_array(sdram->cs, 2);
+
+	init_gpio_pin_array(sdram->addr, 13);
+	init_gpio_pin_array(sdram->bank_addr, 2);
+	gpio_init_pin(sdram->row_addr_strobe);
+	gpio_init_pin(sdram->col_addr_strobe);
+
+	init_gpio_pin_array(sdram->data, 32);
+
+	gpio_init_pin(sdram->write_enable);
+	init_gpio_pin_array(sdram->byte_mask, 4);
+
+	// setup the config registers (1)
+	sdcr = FMC_Bank5_6->SDCR[sdram->bank];
+	sdcr &= ~0x7fff; // reset all the setup
+	sdcr = sdram->read_pipe_delay | sdram->read_burst | sdram->clk_period | \
+			FMC_Write_Protection_Enable | sdram->cas_latency | sdram->internal_bank | \
+			sdram->data_width | sdram->row_bits | sdram->col_bits;
+	if (sdram->bank)
+	{
+		// because the SDCR2 RPIPE, RBURST, and SDCLK are don't care
+		// and refer to the SDRC1 bits for both banks we must set these
+		// here if we are dealing with bank 2
+		//uint32_t sdcr0;
+		sdcr0 = FMC_Bank5_6->SDCR[0];
+		sdcr0 &= ~0x7c00; // this will override RPIPE, RBURST, SDCLK for both banks
+		sdcr0 = sdram->read_pipe_delay | sdram->read_burst | sdram->clk_period;
+		FMC_Bank5_6->SDCR[0] = sdcr0;
+	}
+	FMC_Bank5_6->SDCR[sdram->bank] = sdcr;
+
+	// init timing registers (2)
+	sdtr = FMC_Bank5_6->SDTR[sdram->bank];
+	sdtr &= ~0xfffffff; // reset all the timing
+	sdtr |= FORMAT_TIMING_REG(sdram->trcd, 24) | FORMAT_TIMING_REG(sdram->trp, 20) | \
+			FORMAT_TIMING_REG(sdram->twr, 16) | FORMAT_TIMING_REG(sdram->trc, 12) | \
+			FORMAT_TIMING_REG(sdram->tras, 8) | FORMAT_TIMING_REG(sdram->txsr, 4) | \
+			FORMAT_TIMING_REG(sdram->tmrd, 0);
+	if (sdram->bank)
+	{
+		// because the SDTR2 TRP (row_pre_charge_delay), TRC (trc)
+		// are don't care and refer to the SDTR1 bits for both banks we must
+		// set these here if we are dealing with bank 2
+		//uint32_t sdtr0;
+		sdtr0 = FMC_Bank5_6->SDTR[0];
+		sdtr0 &= ~0xf0f000; // this will override TRP, and TRC for both banks
+		sdtr0 |= FORMAT_TIMING_REG(sdram->trp, 20) | FORMAT_TIMING_REG(sdram->trc, 12);
+		FMC_Bank5_6->SDTR[0] = sdtr0;
+	}
+	FMC_Bank5_6->SDTR[sdram->bank] = sdtr;
+
+	// enable the fmc clk (3)
+	fmc_sdram_cmd(sdram->bank, FMC_Command_Mode_CLK_Enabled, 1, 0);
+
+	// wait delay time for the sdram to init (4)
+	sys_spin(sdram->power_on_delay);
+
+	// precharge all (5)
+	fmc_sdram_cmd(sdram->bank, FMC_Command_Mode_PALL, 1, 0);
+
+	// configure the auto refresh cycles (6)
+	fmc_sdram_cmd(sdram->bank, FMC_Command_Mode_AutoRefresh, sdram->auto_refresh_cycles, 0);
+
+	// configure the MRD field (7)
+	fmc_sdram_cmd(sdram->bank, FMC_Command_Mode_LoadMode, 1, sdram->mdr);
+
+	// refresh count (8)
+	FMC_Bank5_6->SDRTR |= (sdram->refresh_rate & 0x1fff) << 1;
+
+	// set write protect and we are done
+	sdcr &= ~(FMC_Write_Protection_Enable); // clear bits
+	sdcr |= sdram->write_protect;
+	FMC_Bank5_6->SDCR[sdram->bank] = sdcr;
+}
+

--- a/hal/stm32f4/fmc.h
+++ b/hal/stm32f4/fmc.h
@@ -1,0 +1,29 @@
+/**
+ * @file fmc.h
+ *
+ * @brief interface to flexible memory controller module of the hal
+ *
+ * @author OT
+ *
+ * @date June 2018
+ *
+ */
+
+
+#ifndef __FMC__
+#define __FMC__
+
+/**
+ * @brief opaque sdram
+ */
+typedef struct fmc_sdram_t fmc_sdram_t;
+
+
+/**
+ * @brief initalise an sdram using the flxible memory controller to map it into the system address space
+ * @param sdram sdram chip to use
+ * @note this function only works for the stm32f42xxx/stm32f43xxx series
+ */
+void fmc_sdram_init(fmc_sdram_t *sdram);
+
+#endif

--- a/hal/stm32f4/fmc_hw.h
+++ b/hal/stm32f4/fmc_hw.h
@@ -1,0 +1,65 @@
+/**
+ * @file fmc.h
+ *
+ * @brief this contains hw definitions for configuration via hw.c only (it is not a run time interface !)
+ *
+ * @author OT
+ *
+ * @date Jan 2018
+ *
+ */
+
+#ifndef __FMC_HW__
+#define __FMC_HW__
+
+
+#include "hal.h"
+#include "gpio_hw.h"
+
+
+// internal representation of a adc
+struct fmc_sdram_t
+{
+	// gpio to the sdram chip
+	gpio_pin_t *clk;
+	gpio_pin_t *clk_en[2];
+	gpio_pin_t *cs[2];
+
+	gpio_pin_t *addr[13];
+	gpio_pin_t *bank_addr[2];
+	gpio_pin_t *row_addr_strobe;
+	gpio_pin_t *col_addr_strobe;
+
+	gpio_pin_t *data[32];
+
+	gpio_pin_t *write_enable;
+	gpio_pin_t *byte_mask[4];
+
+	// config
+	uint8_t bank;  // selects the stm32f4 bank, ie bank 1 [0] or bank 2 [1] (see FMC_SDRAM_Bank)
+	uint32_t read_pipe_delay;  // see FMC_ReadPipe_Delay in HCLK cycles (note this is a global flag shared by both banks)
+	uint32_t read_burst;  // see FMC_Read_Burst (note this is a global flag shared by both banks)
+	uint32_t clk_period;  // see FMC_SDClock_Period (note this is a global flag shared by both banks)
+	uint32_t write_protect;  // see FMC_Write_Protection
+	uint32_t cas_latency;  // see FMC_CAS_Latency
+	uint32_t internal_bank;  // see FMC_InternalBank_Number
+	uint32_t data_width;  // see FMC_SDMemory_Data_Width
+	uint32_t row_bits;  // see FMC_RowBits_Number
+	uint32_t col_bits;  // see FMC_ColumnBits_Number
+	uint32_t auto_refresh_cycles; // the number of auto refresh cycles for this sdram chip (1 .. 15, typical 8)
+
+	// timing (all units 1..16 in clock cycles, see clk_period above)
+	uint8_t trcd; // delay between cmd and r/w operation
+	uint8_t trp; // delay between precharge cmd and next op (note this is a global flag shared by both banks)
+	uint8_t twr; // delay between a write and precharge cmd (this must match the slowest sdram chip present)
+	uint8_t trc; // delay between refresh cmd and active/refresh cmd (note this is a global flag shared by both banks)
+	uint8_t tras; // minimum self refresh period
+	uint8_t txsr; // delay from self refresh cmd to active cmd
+	uint8_t tmrd; // delay between a load mode register cmd and an active refresh cmd
+
+	uint32_t power_on_delay; // delay from the sdram datasheet from power on to talking (in ms)
+	uint16_t mdr; // load this value into the mdr
+	uint16_t refresh_rate; // refresh timer value loaded into the SDRTR register (in SDCLK cycles)
+};
+
+#endif

--- a/hal/stm32f4/hal.h
+++ b/hal/stm32f4/hal.h
@@ -28,6 +28,7 @@
 #include "spis.h"
 #include "spim.h"
 #include "nvm.h"
+#include "fmc.h"
 #include "crc.h"
 #include "adc.h"
 #include "tmr.h"

--- a/hal/stm32f4/stm32f4.mk
+++ b/hal/stm32f4/stm32f4.mk
@@ -11,9 +11,12 @@ export BIN  = $(CROSS_COMPILE)objcopy -O ihex
 export SIZE = $(CROSS_COMPILE)size
 export GDB = $(CROSS_COMPILE)gdb
 
+# default sub arch to basic stm32f4 peripherals (override this to get all the goodies)
+SUB_ARCH ?= STM32F40_41xxx
+
 MCU = cortex-m4
 FPU = -mfloat-abi=hard -mfpu=fpv4-sp-d16 -D__FPU_USED=1 -D__FPU_PRESENT=1 -DARM_MATH_CM4
-DEFS = -DUSE_STDPERIPH_DRIVER -DSTM32F40_41xxx -DRUN_FROM_FLASH=1 -DHSE_VALUE=8000000
+DEFS = -DUSE_STDPERIPH_DRIVER -D$(SUB_ARCH) -DRUN_FROM_FLASH=1 -DHSE_VALUE=8000000
 OPT ?= -O0
 MCFLAGS = -mthumb -mcpu=$(MCU) $(FPU)
 

--- a/utest/sdram/Makefile
+++ b/utest/sdram/Makefile
@@ -1,0 +1,48 @@
+# build the sdram unit test
+export HALCFG := $(shell pwd)/config
+export SUB_ARCH ?= STM32F429_439xx
+
+LIBHAL = ../../hal/libhal.o
+
+.PHONY: all clean $(LIBHAL)
+
+PRJ = sdram_utest
+PRJ_FULL = $(PRJ).hex
+
+include ../../hal/hal.mk
+
+SRC = sdram_utest.c
+SRC += hw.c
+
+OBJS = $(SRC:.c=.o)
+
+INCDIR += ../../hal/
+INC = $(patsubst %,-I%,$(INCDIR))
+
+LDSCRIPT = sdram_utest.ld
+LDFLAGS += -T$(LDSCRIPT)
+
+all: $(PRJ_FULL)
+	echo $(PRJ_FULL)
+
+$(PRJ).elf: $(LIBHAL) $(OBJS) $(LDSCRIPT)
+	$(CC) $(OBJS) $(LIBHAL) -Wl,-Map=$(PRJ).map $(LDFLAGS) -o $@
+
+$(LIBHAL):
+	make -C ../../hal
+
+%.hex: %.elf
+	$(BIN) $< $@
+
+%.o : %.c
+	$(CC) -c $(CPFLAGS) -Wa,-ahlms=$(<:.c=.lst) -I . $(INC) $< -o $@
+
+clean:
+	-rm -f $(OBJS)
+	-rm -f $(OBJS:.o=.lst)
+	-rm -f $(PRJ).lst
+	-rm -f $(PRJ).map
+	-rm -f $(PRJ).elf
+	-rm -f $(PRJ_FULL)
+	make -C ../../hal clean
+

--- a/utest/sdram/config
+++ b/utest/sdram/config
@@ -1,0 +1,3 @@
+CONFIG_DMA = y
+CONFIG_GPIO = y
+CONFIG_SPIS = y

--- a/utest/sdram/debug_sdram_utest.gdbinit
+++ b/utest/sdram/debug_sdram_utest.gdbinit
@@ -1,0 +1,10 @@
+file sdram_utest.elf
+target remote localhost:3333
+mon reset halt
+tbreak main
+c
+
+define reset
+	mon reset halt
+end
+

--- a/utest/sdram/hw.c
+++ b/utest/sdram/hw.c
@@ -1,0 +1,170 @@
+/**
+ * @file hw.c
+ * 
+ * @brief implements the default hw available on the stm32f429 disco board
+ *
+ * @see hw.h for instructions to override the defaults
+ *
+ * @author OT
+ *
+ * @date Jan 2018
+ *
+ */
+
+#include <hal.h>
+
+
+#if defined(STM32F427_437xx) || defined(STM32F429_439xx) || defined(STM32F446xx) || defined(STM32F469_479xx)
+
+	#include <stm32f4xx_conf.h>
+
+	//
+	// spi
+	//
+	#include <gpio_hw.h>
+	gpio_pin_t gpio_spi1_nss    = {GPIOA, {GPIO_Pin_4, GPIO_Mode_AF, GPIO_Speed_50MHz}, 5};
+	gpio_pin_t gpio_spi1_sck    = {GPIOA, {GPIO_Pin_5,  GPIO_Mode_AF, GPIO_Speed_50MHz}, 5};
+	gpio_pin_t gpio_spi1_miso   = {GPIOA, {GPIO_Pin_6,  GPIO_Mode_AF, GPIO_Speed_50MHz}, 5};
+	gpio_pin_t gpio_spi1_mosi   = {GPIOA, {GPIO_Pin_7,  GPIO_Mode_AF, GPIO_Speed_50MHz}, 5};
+
+	#include <dma_hw.h>
+	dma_t spis_rx_dma =
+	{
+		.stream = DMA2_Stream0,
+		.channel = DMA_Channel_3,
+	};
+	dma_t spis_tx_dma =
+	{
+		.stream = DMA2_Stream3,
+		.channel = DMA_Channel_3,
+	};
+
+	#include <spis_hw.h>
+	spis_t spis_dev =
+	{
+		.channel = SPI1,   // channel
+		.st_spi_init = {SPI_Direction_2Lines_FullDuplex, SPI_Mode_Slave, SPI_DataSize_8b, SPI_CPOL_Low, SPI_CPHA_1Edge, SPI_NSS_Hard, SPI_BaudRatePrescaler_2, SPI_FirstBit_MSB, 0},
+		.nss = &gpio_spi1_nss, // select line gpio
+		.sck = &gpio_spi1_sck, // clk line gpio
+		.miso = &gpio_spi1_miso, // miso gpio
+		.mosi = &gpio_spi1_mosi, // mosi gpio
+
+		.rx_dma = &spis_rx_dma,
+		.tx_dma = &spis_tx_dma,
+	};
+
+	//
+	// sd ram
+	//
+	#include <gpio_hw.h>
+	#include <fmc_hw.h>
+	gpio_pin_t sdclk_pg8 = { .port = GPIOG, .cfg = {.GPIO_Pin = GPIO_Pin_8, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t sdcke1_pb5 = { .port = GPIOB, .cfg = {.GPIO_Pin = GPIO_Pin_5, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t sdne1_pb6 = { .port = GPIOB, .cfg = {.GPIO_Pin = GPIO_Pin_6, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+
+	gpio_pin_t a0_pf0 = {.port = GPIOF, .cfg = {.GPIO_Pin = GPIO_Pin_0, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t a1_pf1 = {.port = GPIOF, .cfg = {.GPIO_Pin = GPIO_Pin_1, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t a2_pf2 = {.port = GPIOF, .cfg = {.GPIO_Pin = GPIO_Pin_2, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t a3_pf3 = {.port = GPIOF, .cfg = {.GPIO_Pin = GPIO_Pin_3, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t a4_pf4 = {.port = GPIOF, .cfg = {.GPIO_Pin = GPIO_Pin_4, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t a5_pf5 = {.port = GPIOF, .cfg = {.GPIO_Pin = GPIO_Pin_5, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t a6_pf12 = {.port = GPIOF, .cfg = {.GPIO_Pin = GPIO_Pin_12, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t a7_pf13 = {.port = GPIOF, .cfg = {.GPIO_Pin = GPIO_Pin_13, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t a8_pf14 = {.port = GPIOF, .cfg = {.GPIO_Pin = GPIO_Pin_14, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t a9_pf15 = {.port = GPIOF, .cfg = {.GPIO_Pin = GPIO_Pin_15, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t a10_pg0 = {.port = GPIOG, .cfg = {.GPIO_Pin = GPIO_Pin_0, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t a11_pg1 = {.port = GPIOG, .cfg = {.GPIO_Pin = GPIO_Pin_1, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+
+	gpio_pin_t d0_pd14 = {.port = GPIOD, .cfg = {.GPIO_Pin = GPIO_Pin_14, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d1_pd15 = {.port = GPIOD, .cfg = {.GPIO_Pin = GPIO_Pin_15, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d2_pd0 = {.port = GPIOD, .cfg = {.GPIO_Pin = GPIO_Pin_0, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d3_pd1 = {.port = GPIOD, .cfg = {.GPIO_Pin = GPIO_Pin_1, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d4_pe7 = {.port = GPIOE, .cfg = {.GPIO_Pin = GPIO_Pin_7, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d5_pe8 = {.port = GPIOE, .cfg = {.GPIO_Pin = GPIO_Pin_8, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d6_pe9 = {.port = GPIOE, .cfg = {.GPIO_Pin = GPIO_Pin_9, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d7_pe10 = {.port = GPIOE, .cfg = {.GPIO_Pin = GPIO_Pin_10, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d8_pe11 = {.port = GPIOE, .cfg = {.GPIO_Pin = GPIO_Pin_11, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d9_pe12 = {.port = GPIOE, .cfg = {.GPIO_Pin = GPIO_Pin_12, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d10_pe13 = {.port = GPIOE, .cfg = {.GPIO_Pin = GPIO_Pin_13, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d11_pe14 = {.port = GPIOE, .cfg = {.GPIO_Pin = GPIO_Pin_14, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d12_pe15 = {.port = GPIOE, .cfg = {.GPIO_Pin = GPIO_Pin_15, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d13_pd8 = {.port = GPIOD, .cfg = {.GPIO_Pin = GPIO_Pin_8, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d14_pd9 = {.port = GPIOD, .cfg = {.GPIO_Pin = GPIO_Pin_9, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t d15_pd10 = {.port = GPIOD, .cfg = {.GPIO_Pin = GPIO_Pin_10, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+
+	gpio_pin_t ba0_pg4 = {.port = GPIOG, .cfg = {.GPIO_Pin = GPIO_Pin_4, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t ba1_pg5 = {.port = GPIOG, .cfg = {.GPIO_Pin = GPIO_Pin_5, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+
+	gpio_pin_t sdnras_pf11 = {.port = GPIOF, .cfg = {.GPIO_Pin = GPIO_Pin_11, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t sdncas_pg15 = {.port = GPIOG, .cfg = {.GPIO_Pin = GPIO_Pin_15, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t sdnwe_pc0 = {.port = GPIOC, .cfg = {.GPIO_Pin = GPIO_Pin_0, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+
+	gpio_pin_t nbl0_pe0 = {.port = GPIOE, .cfg = {.GPIO_Pin = GPIO_Pin_0, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+	gpio_pin_t nbl1_pe1 = {.port = GPIOE, .cfg = {.GPIO_Pin = GPIO_Pin_1, .GPIO_Mode = GPIO_Mode_AF, .GPIO_Speed=GPIO_Speed_50MHz, .GPIO_PuPd = GPIO_PuPd_NOPULL}, .af = 12};
+
+
+	// see IS42S16400J data sheet (page 19)
+	#define IS42S16400J_BURST_LEN2 (0x001)
+	#define IS42S16400J_BURST_TYPE_SEQUENTIAL (0x000)
+	#define IS42S16400J_CAS_LATENCY_3 (0x030)
+	#define IS42S16400J_OPERATING_MODE_STD (0x000)
+	#define IS42S16400J_WRITE_BURST_MODE_SINGLE (0x200)
+
+	fmc_sdram_t sdram = {
+		// gpio
+		.clk = &sdclk_pg8,
+		.clk_en = {&sdcke1_pb5,},
+		.cs = {&sdne1_pb6,},
+		.addr = {
+			&a0_pf0, &a1_pf1, &a2_pf2, &a3_pf3, &a4_pf4, &a5_pf5, &a6_pf12,
+			&a7_pf13, &a8_pf14, &a9_pf15, &a10_pg0, &a11_pg1,
+		},
+		.bank_addr = {&ba0_pg4, &ba1_pg5,},
+		.row_addr_strobe = &sdnras_pf11,
+		.col_addr_strobe = &sdncas_pg15,
+		.data = {
+			&d0_pd14, &d1_pd15, &d2_pd0, &d3_pd1, &d4_pe7, &d5_pe8, &d6_pe9,
+			&d7_pe10, &d8_pe11, &d9_pe12, &d10_pe13, &d11_pe14, &d12_pe15,
+			&d13_pd8, &d14_pd9, &d15_pd10,
+		},
+		.write_enable = &sdnwe_pc0,
+		.byte_mask = {&nbl0_pe0, &nbl1_pe1,},
+
+		// sdram config
+		.bank = 1,
+		.read_pipe_delay = FMC_ReadPipe_Delay_1,
+		.read_burst = FMC_Read_Burst_Disable,
+		.clk_period = FMC_SDClock_Period_2, // HCLK=168MHz, SDCLK < 143MHz(@cas_latency=3), SDCLK=143MHz/2=84Mhz
+		.write_protect = FMC_Write_Protection_Disable,
+		.cas_latency = FMC_CAS_Latency_3, // so we can go as fast as possible
+		.internal_bank = FMC_InternalBank_Number_4,
+		.data_width = FMC_SDMemory_Width_16b,
+		.row_bits = FMC_RowBits_Number_12b,
+		.col_bits = FMC_ColumnBits_Number_8b,
+		.auto_refresh_cycles = 4,
+
+		// timings (HCLK=168MHz, SDCLK=HCLK/2=84MHz -> 12ns) (see IS42S16400J datasheet p16 for details)
+		.trcd = 2, // > 15ns * 84MHz = 1.26cyc -> 2cyc
+		.trp = 2, // > 15ns * 84MHz = 1.26cyc -> 2cyc
+		.twr = 2, // > 2CLK -> 2cyc
+		.trc = 7, // > 63ns * 84MHz = 5.3cyc -> 6cyc
+		.tras = 4, // > 42ns * 84MHz = 3.5cyc -> 4cyc && < 100us * 84MHz = 8400cyc
+		.txsr = 7, // > 70ns * 84MHz = 5.9ns -> 6cyc
+		.tmrd = 2, // 2cyc
+
+		.power_on_delay = 100, // supposedly 1cyc, but this is done once on startup so just wait a long time to be sure
+		.mdr = \
+			IS42S16400J_BURST_LEN2 | \
+			IS42S16400J_BURST_TYPE_SEQUENTIAL | \
+			IS42S16400J_CAS_LATENCY_3 | \
+			IS42S16400J_OPERATING_MODE_STD | \
+			IS42S16400J_WRITE_BURST_MODE_SINGLE,
+
+		.refresh_rate = 1292, // < rate 64ms/4096rows = 15.6us -> (15.6us* 84MHz) - 20 = 1292.5cyc -> 1292cyc
+	};
+
+#else
+
+	#error "sdram not supported on unknown target"
+
+#endif

--- a/utest/sdram/hw.h
+++ b/utest/sdram/hw.h
@@ -1,0 +1,21 @@
+/**
+ * @file hw.h
+ * 
+ * @brief default hw available on the stm32f429 disco system for this unit test (pins/peripheral setups etc)
+ *
+ * @note to override the defaults make your own definitions in your hw.c and include that in the build not the default. Then expose them in your own hw.h (defining __HW__) before inluding mos.h or hal.h
+ *
+ * @author OT
+ *
+ * @date Jun 2018
+ *
+ */
+
+#ifndef __HW__
+#define __HW__
+
+extern spis_t spis_dev;
+extern fmc_sdram_t sdram;
+
+#endif
+

--- a/utest/sdram/sdram_utest.c
+++ b/utest/sdram/sdram_utest.c
@@ -1,0 +1,66 @@
+/**
+ * @file sdram_utest.c
+ *
+ * @brief unit test the sdram hal module
+ *
+ * This test is designed to check the sdram module.
+ *
+ * @author OT
+ *
+ * @date Jun 2018
+ *
+ */
+
+#include <string.h>
+#include <hal.h>
+
+
+#define SDRAM_ADDR (0xd0000000)
+volatile uint8_t buf[8*1024*1024] at_symbol(".sdram"); // give me all the bytes :)
+
+
+void fail(void)
+{
+	while (1);
+}
+
+
+void read_complete(spis_t *spis, void *buf, uint16_t len, void *param)
+{
+	// keep going
+	spis_read(&spis_dev, (void *)buf, 32, read_complete, NULL);
+}
+
+
+void init(void)
+{
+	sys_init();
+	spis_init(&spis_dev);
+	fmc_sdram_init(&sdram);
+}
+
+
+int main(void)
+{
+	long long n;
+	uint8_t k;
+
+	init();
+
+	*(uint8_t *)(SDRAM_ADDR) = 0xee;
+
+	// write all the bytes to the sdram and check they are there
+	for (n = 0, k = 0; n < sizeof(buf); n++, k++)
+		buf[n] = k;
+
+	for (n = 0, k = 0; n < sizeof(buf); n++, k++)
+		if (buf[n] != k)
+			fail();
+
+	// wait for a spi packet to be DMA'ed into the buffer
+	spis_read(&spis_dev, (void *)buf, 32, read_complete, NULL);
+	while (1);
+
+	return 0;
+}
+

--- a/utest/sdram/sdram_utest.ld
+++ b/utest/sdram/sdram_utest.ld
@@ -1,0 +1,216 @@
+MEMORY
+{
+  RAM (xrw) : ORIGIN = 0x20000000, LENGTH = 192K
+  SDRAM (xrw) : ORIGIN = 0xd0000000, LENGTH = 8M
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 2*16K
+  FREE_PAGE0(xrx) : ORIGIN = 0x08008000, LENGTH = 2*16K
+  FREE_PAGE1(xrx) : ORIGIN = 0x08010000, LENGTH = 64K 
+}
+
+/* higher address of the user mode stack */
+_estack = 0x20000000 + 192K;
+_Minimum_Stack_Size = 0x3000 ;
+
+
+
+/* include the sections management sub-script for FLASH mode */
+
+/* Sections Definitions */
+
+SECTIONS
+{
+	/* for Cortex devices, the beginning of the startup code is stored in the .isr_vector section, which goes to FLASH */
+	.isr_vector :
+	{
+		. = ALIGN(4);
+		KEEP(*(.isr_vector))			/* Startup code */
+		. = ALIGN(4);
+	} >FLASH
+
+	/* the program code is stored in the .text section, which goes to Flash */
+	.text :
+	{
+		. = ALIGN(4);
+
+		*(.text .text.* .gnu.linkonce.t.*)
+		*(.plt)
+		*(.gnu.warning)
+		*(.glue_7t) *(.glue_7) *(.vfp11_veneer)
+
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.gcc_except_table)
+
+	} >FLASH
+
+	.eh_frame_hdr : ALIGN (4)
+	{
+		KEEP (*(.eh_frame_hdr))
+	} >FLASH
+
+	.eh_frame : ALIGN (4)
+	{
+		KEEP (*(.eh_frame))
+	} >FLASH
+
+	/* .ARM.exidx is sorted, so has to go in its own output section.  */
+	__exidx_start = .;
+	.ARM.exidx :
+	{
+		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
+	} >FLASH
+	__exidx_end = .;
+
+	.rodata : ALIGN (4)
+	{
+		*(.rodata .rodata.* .gnu.linkonce.r.*)
+
+		. = ALIGN(4);
+		KEEP(*(.init))
+
+		. = ALIGN(4);
+		__preinit_array_start = .;
+		KEEP (*(.preinit_array))
+		__preinit_array_end = .;
+
+		. = ALIGN(4);
+		__init_array_start = .;
+		KEEP (*(SORT(.init_array.*)))
+		KEEP (*(.init_array))
+		__init_array_end = .;
+
+		. = ALIGN(4);
+		KEEP(*(.fini))
+
+		. = ALIGN(4);
+		__fini_array_start = .;
+		KEEP (*(.fini_array))
+		KEEP (*(SORT(.fini_array.*)))
+		__fini_array_end = .;
+
+		. = ALIGN(4);
+		KEEP (*crtbegin.o(.ctors))
+		KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+		KEEP (*(SORT(.ctors.*)))
+		KEEP (*crtend.o(.ctors))
+
+		. = ALIGN(4);
+		KEEP (*crtbegin.o(.dtors))
+		KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+		KEEP (*(SORT(.dtors.*)))
+		KEEP (*crtend.o(.dtors))
+
+		. = ALIGN(4);
+		_etext = .;
+		/* This is used by the startup in order to initialize the .data secion */
+		_sidata = _etext;
+	} >FLASH
+
+	.sdram (NOLOAD) :
+	{
+		__esdram = . + LENGTH(SDRAM);
+		. = ALIGN(4);
+		KEEP(*(.sdram)) /* sdram */
+	} >SDRAM
+
+
+	/* This is the initialized data section
+	The program executes knowing that the data is in the RAM
+	but the loader puts the initial values in the FLASH (inidata).
+	It is one task of the startup to copy the initial values from FLASH to RAM. */
+	.data  : AT ( _sidata )
+	{
+		. = ALIGN(4);
+		/* This is used by the startup in order to initialize the .data secion */
+		_sdata = . ;
+
+		KEEP(*(.jcr))
+		*(.got.plt) *(.got)
+		*(.shdata)
+		*(.data .data.* .gnu.linkonce.d.*)
+
+		. = ALIGN(4);
+		/* This is used by the startup in order to initialize the .data secion */
+		_edata = . ;
+	} >RAM
+
+	/* This is the uninitialized data section */
+	.bss :
+	{
+		. = ALIGN(4);
+		/* This is used by the startup in order to initialize the .bss secion */
+		_sbss = .;
+
+		*(.shbss)
+		*(.bss .bss.* .gnu.linkonce.b.*)
+		*(COMMON)
+
+		. = ALIGN(4);
+		/* This is used by the startup in order to initialize the .bss secion */
+		_ebss = . ;
+	} >RAM
+
+	PROVIDE ( end = _ebss );
+	PROVIDE ( _end = _ebss );
+
+	/* This is the user stack section
+	This is just to check that there is enough RAM left for the User mode stack
+	It should generate an error if it's full.
+	 */
+	._usrstack :
+	{
+		. = ALIGN(4);
+		_susrstack = . ;
+
+		. = . + _Minimum_Stack_Size ;
+
+		. = ALIGN(4);
+		_eusrstack = . ;
+	} >RAM
+
+	/* remove the debugging information from the standard libraries */
+	DISCARD :
+	{
+		libc.a ( * )
+		libm.a ( * )
+		libgcc.a ( * )
+	}
+
+	/* Stabs debugging sections.  */
+	.stab		  0 : { *(.stab) }
+	.stabstr	   0 : { *(.stabstr) }
+	.stab.excl	 0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index	0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment	   0 : { *(.comment) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1 */
+	.debug		  0 : { *(.debug) }
+	.line		   0 : { *(.line) }
+	/* GNU DWARF 1 extensions */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2 */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2 */
+	.debug_info	 0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line	 0 : { *(.debug_line) }
+	.debug_frame	0 : { *(.debug_frame) }
+	.debug_str	  0 : { *(.debug_str) }
+	.debug_loc	  0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+
+	note.gnu.arm.ident 0 : { KEEP (*(.note.gnu.arm.ident)) }
+	.ARM.attributes 0 : { KEEP (*(.ARM.attributes)) }
+	/DISCARD/ : { *(.note.GNU-stack) }
+}
+


### PR DESCRIPTION
some of the stm32f4 line feature a flexible memory controller that
allows additional external memory to be added to the system bus .. this
change allows external memory to be added to the system bus via the
fmc_sdram_init() call

a unit test in utest/sdram is available to debug issue and as an example
to follow, it is designed to work on the stm32f429 disco board, but can
easily be make to work on any stm32f4 connected to the IS42S16400J or
similar sdram ... initially it checks we can read/write the entire
sdram, then it waits as a SPI slave and DMA's those bytes directly into
the sdram