### PR TITLE
fix edge events on ports other than A

### DIFF
--- a/hal/stm32f373/gpio.c
+++ b/hal/stm32f373/gpio.c
@@ -356,6 +356,7 @@ static void gpio_set_edge_event(gpio_pin_t *pin, EXTITrigger_TypeDef trig, gpio_
 	uint32_t exti_line = gpio_pin_to_exti_line(pin);
 
 	// set pin to EXTI mode
+	RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
 	SYSCFG_EXTILineConfig(gpio_pin_to_port_source(pin), gpio_pin_to_pin_source(pin));
 
 	// Configure EXTIx line to trigger irq

--- a/hal/stm32f4/gpio.c
+++ b/hal/stm32f4/gpio.c
@@ -335,7 +335,7 @@ void EXTI1_IRQHandler(void)
 }
 
 
-void EXTI2_TS_IRQHandler(void)
+void EXTI2_IRQHandler(void)
 {
 	exti_isr(2, 2);
 }
@@ -376,6 +376,7 @@ static void gpio_set_edge_event(gpio_pin_t *pin, EXTITrigger_TypeDef trig, gpio_
 	uint32_t exti_line = gpio_pin_to_exti_line(pin);
 
 	// set pin to EXTI mode
+	RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
 	SYSCFG_EXTILineConfig(gpio_pin_to_port_source(pin), gpio_pin_to_pin_source(pin));
 
 	// Configure EXTIx line to trigger irq

--- a/utest/gpio/hw.c
+++ b/utest/gpio/hw.c
@@ -29,7 +29,7 @@ gpio_pin_t gpio_led3		= {GPIOC, {GPIO_Pin_4,  GPIO_Speed_50MHz, GPIO_Mode_Out_PP
 
 #include <stm32f37x_conf.h>
 #include <gpio_hw.h>
-gpio_pin_t gpio_in 			= {GPIOA, {GPIO_Pin_2, GPIO_Mode_IN, GPIO_Speed_50MHz, 0, GPIO_PuPd_NOPULL}};
+gpio_pin_t gpio_in 			= {GPIOB, {GPIO_Pin_0, GPIO_Mode_IN, GPIO_Speed_50MHz, 0, GPIO_PuPd_NOPULL}};
 gpio_pin_t gpio_led0		= {GPIOC, {GPIO_Pin_0,  GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL}};
 gpio_pin_t gpio_led1		= {GPIOC, {GPIO_Pin_1,  GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL}};
 gpio_pin_t gpio_led2		= {GPIOC, {GPIO_Pin_2,  GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL}};
@@ -40,7 +40,7 @@ gpio_pin_t gpio_tri_state	= {GPIOA, {GPIO_Pin_3,  GPIO_Mode_OUT, GPIO_Speed_50MH
 
 #include <stm32f4xx_conf.h>
 #include <gpio_hw.h>
-gpio_pin_t gpio_in 			= {GPIOA, {GPIO_Pin_0,  GPIO_Mode_IN, GPIO_Speed_50MHz, 0, GPIO_PuPd_NOPULL}};
+gpio_pin_t gpio_in 			= {GPIOB, {GPIO_Pin_2,  GPIO_Mode_IN, GPIO_Speed_50MHz, 0, GPIO_PuPd_NOPULL}};
 gpio_pin_t gpio_led0		= {GPIOC, {GPIO_Pin_0,  GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL}};
 gpio_pin_t gpio_led1		= {GPIOC, {GPIO_Pin_1,  GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL}};
 gpio_pin_t gpio_led2		= {GPIOC, {GPIO_Pin_2,  GPIO_Mode_OUT, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_NOPULL}};


### PR DESCRIPTION
in order to set the EXTICR register in the SYSCFG the SYSCFG clock must
first be enabled otherwise writes to this register will be ignored and
the value will remain at its default of 0x00000000 (all PORTA) ... hence
only PORTA interrupts will be seen

now the SYSCFG is enabled this should work on any port pin

also I noticed we copied the old stm32f3 EXTI2_TS_IRQHandler ISR name,
but on the F4 we actually should be overriding the weak EXTI2_IRQHandler
ISR (just a name change) so this was fix also