### PR TITLE
fix adc_cancel_trace bug on the stm32f4

### DIFF
--- a/hal/stm32f4/adc.c
+++ b/hal/stm32f4/adc.c
@@ -223,6 +223,7 @@ void adc_cancel_trace(adc_channel_t *ch)
 	if (adc->dma == NULL)
 		///@todo error current implementation does not support interrupts so we need a dma
 		return;
+	ADC_DMACmd(adc->base, DISABLE);
 	dma_cancel(adc->dma); // cancel any pending/running dma
 	sys_leave_critical_section();
 }


### PR DESCRIPTION
the adc_cancel_trace did not work on the stm32f4 ... if the DMA is not
disabled first (ie this patch) then the ADC overflow status flag
triggers and this stops the ADC from triggering the DMA until that error
is cleared