### PR TITLE
Changes and fixes needed to make this work with multiple devices on the bus

### DIFF
--- a/hal/stm32f373/spim.c
+++ b/hal/stm32f373/spim.c
@@ -121,7 +121,13 @@ void spim_irq_handler(int n)
 	
 	// write phase (reload the Tx register if it is empty and the isr is enabled)
 	if (SPI_I2S_GetITStatus(spim->channel, SPI_I2S_IT_TXE) == SET)
-		spim_write_phase(spim);
+	{
+		if (!spim_write_phase(spim))
+		{
+			// All data sent, disable the TXE interrupt
+			SPI_I2S_ITConfig(spim->channel, SPI_I2S_IT_TXE, DISABLE);
+		}
+	}
 
 	// handle completion callback
 	if (spim->read_count == spim->len)
@@ -142,9 +148,8 @@ void spim_irq_handler(int n)
 }
 
 
-void spim_rx_dma_complete(dma_request_t *req, void *param)
+void spim_dma_complete(spim_t *spim)
 {
-	spim_t *spim = (spim_t *)param;
 	spim_xfer_complete complete = spim->xfer_complete;
 	void *spim_xfer_param = spim->xfer_complete_param;
 	void *read_buf = spim->read_buf;
@@ -157,6 +162,24 @@ void spim_rx_dma_complete(dma_request_t *req, void *param)
 	spim_clear_io(spim);
 	if (complete != NULL)
 		complete(spim, spim->addr, read_buf, write_buf, len, spim_xfer_param);
+}
+
+void spim_rx_dma_complete(dma_request_t *req, void *param)
+{
+	spim_t *spim = (spim_t *)param;
+
+	spim->rx_completed = true;
+	if (spim->tx_completed)
+		spim_dma_complete(spim);
+}
+
+void spim_tx_dma_complete(dma_request_t *req, void *param)
+{
+	spim_t *spim = (spim_t *)param;
+
+	spim->tx_completed = true;
+	if (spim->rx_completed)
+		spim_dma_complete(spim);
 }
 
 
@@ -174,10 +197,11 @@ static const struct prescalers_t {
 	{.scale = 256, .reg = SPI_BaudRatePrescaler_256},
 };
 
-void spim_xfer(spim_t *spim, spim_xfer_opts *opts, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param)
+bool spim_xfer(spim_t *spim, spim_xfer_opts *opts, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param)
 {
 	float fclk = spi_get_clk_speed(spim->channel);
 	int k;
+	bool success = true;
 
 	// update speed from opts if needed (do this outside critical section)
 	if (opts->speed)
@@ -197,8 +221,11 @@ success:
 
 	if (spim->read_buf != NULL || spim->read_count != 0 ||
 		spim->write_buf != NULL || spim->write_count != 0)
-		///@todo xfer in progress already
+	{
+		// A transfer is already in progress
+		success = false;
 		goto done;
+	}
 
 	// load xfer details
 	spim->addr = addr;
@@ -224,6 +251,7 @@ success:
 		spim->rx_dma_req.complete = spim_rx_dma_complete;
 		spim->rx_dma_req.complete_param = spim;
 		spim->rx_dma_req.dma = spim->rx_dma;
+		spim->rx_completed = false;
 		spi_dma_cfg(SPI_DMA_DIR_RX, spim->channel, &spim->rx_dma_req, spim->read_buf, spim->len);
 		SPI_I2S_DMACmd(spim->channel, SPI_I2S_DMAReq_Rx, ENABLE);
 		dma_request(&spim->rx_dma_req);
@@ -240,11 +268,10 @@ success:
 	}
 	else
 	{
-		// since we complete when the last byte is read (this obviously happens after the last byte
-		// is transmitted) we don't need a complete routine for this.
-		spim->tx_dma_req.complete = NULL;
-		spim->tx_dma_req.complete_param = NULL;
+		spim->tx_dma_req.complete = spim_tx_dma_complete;
+		spim->tx_dma_req.complete_param = spim;
 		spim->tx_dma_req.dma = spim->tx_dma;
+		spim->tx_completed = false;
 		spi_dma_cfg(SPI_DMA_DIR_TX, spim->channel, &spim->tx_dma_req, spim->write_buf, spim->len);
 		SPI_I2S_DMACmd(spim->channel, SPI_I2S_DMAReq_Tx, ENABLE);
 		dma_request(&spim->tx_dma_req);
@@ -252,6 +279,7 @@ success:
 
 done:
 	sys_leave_critical_section();
+	return success;
 }
 
 

--- a/hal/stm32f373/spim.h
+++ b/hal/stm32f373/spim.h
@@ -44,6 +44,8 @@ void spim_init(spim_t *spim);
  */
 typedef void (*spim_xfer_complete)(spim_t *spim, uint16_t addr, void *read_buf, void *write_buf, uint16_t len, void *param);
 
+#define SPIM_OK			0
+#define SPIM_ERROR_BUSY -1	// Transfer already in progress
 
 /**
  * @brief start a spi master transfer
@@ -55,10 +57,17 @@ typedef void (*spim_xfer_complete)(spim_t *spim, uint16_t addr, void *read_buf, 
  * @param len write & read this many byte to/from the read/write buf's
  * @param complete call this when len bytes are transfered
  * @param param complete parameter
- * @return true if the transfer was started, false if the SPI bus was busy and the transfer could not be started
+ * @return number of bytes to be transferred if the transfer was started, or negative error code if the transfer could not be started
  */
-bool spim_xfer(spim_t *spim, spim_xfer_opts *opts, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param);
+int spim_xfer(spim_t *spim, spim_xfer_opts *opts, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param);
 
+/**
+ * @brief return true is the SPI master is busy
+ * @param spim spi master to use
+ * @return true when busy, false if it is OK to start a new transaction
+ *
+ */
+bool spim_busy(spim_t *spim);
 
 /**
  * @brief flush the current spi master xfer

--- a/hal/stm32f373/spim.h
+++ b/hal/stm32f373/spim.h
@@ -55,8 +55,9 @@ typedef void (*spim_xfer_complete)(spim_t *spim, uint16_t addr, void *read_buf, 
  * @param len write & read this many byte to/from the read/write buf's
  * @param complete call this when len bytes are transfered
  * @param param complete parameter
+ * @return true if the transfer was started, false if the SPI bus was busy and the transfer could not be started
  */
-void spim_xfer(spim_t *spim, spim_xfer_opts *opts, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param);
+bool spim_xfer(spim_t *spim, spim_xfer_opts *opts, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param);
 
 
 /**

--- a/hal/stm32f373/spim_hw.h
+++ b/hal/stm32f373/spim_hw.h
@@ -43,9 +43,11 @@ struct spim_t
 	spim_xfer_complete xfer_complete;				///< called once len bytes are transfered
 	void *xfer_complete_param;						///< completion parameter
 	dma_t *rx_dma;									///< optional dma used for rx (ie dont use isr, do it in hw)
+	bool rx_completed;								///< true if the rx dma complete interrupt has been called
 	dma_request_t rx_dma_req;						///< used by rx_dma
 	dma_t *tx_dma;									///< optional dma used for tx (ie dont use isr, do it in hw)
 	dma_request_t tx_dma_req;						///< used by tx_dma
+	bool tx_completed;								///< true if the tx dma complete interrupt has been called
 };
 
 

--- a/hal/stm32f4/spim.c
+++ b/hal/stm32f4/spim.c
@@ -194,11 +194,11 @@ static const struct prescalers_t {
 	{.scale = 256, .reg = SPI_BaudRatePrescaler_256},
 };
 
-bool spim_xfer(spim_t *spim, spim_xfer_opts *opts, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param)
+int spim_xfer(spim_t *spim, spim_xfer_opts *opts, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param)
 {
 	float fclk = spi_get_clk_speed(spim->channel);
 	int k;
-	bool success = true;
+	int result = len;
 
 	// update speed from opts if needed (do this outside critical section)
 	if (opts->speed)
@@ -216,11 +216,10 @@ success:
 
 	sys_enter_critical_section();
 
-	if (spim->read_buf != NULL || spim->read_count != 0 ||
-		spim->write_buf != NULL || spim->write_count != 0)
+	if (spim_busy(spim))
 	{
 		// A transfer is already in progress
-		success = false;
+		result = SPIM_ERROR_BUSY;
 		goto done;
 	}
 
@@ -250,8 +249,8 @@ success:
 		spim->rx_dma_req.dma = spim->rx_dma;
 		spim->rx_completed = false;
 		spi_dma_cfg(SPI_DMA_DIR_RX, spim->channel, &spim->rx_dma_req, spim->read_buf, spim->len);
-		dma_request(&spim->rx_dma_req);
 		SPI_I2S_DMACmd(spim->channel, SPI_I2S_DMAReq_Rx, ENABLE);
+		dma_request(&spim->rx_dma_req);
 	}
 	
 	// init the write
@@ -276,9 +275,14 @@ success:
 
 done:
 	sys_leave_critical_section();
-	return success;
+	return result;
 }
 
+bool spim_busy(spim_t *spim)
+{
+	return ((spim->read_buf != NULL) || (spim->read_count != 0)
+			|| (spim->write_buf != NULL) || (spim->write_count != 0));
+}
 
 void spim_init(spim_t *spim)
 {

--- a/hal/stm32f4/spim.h
+++ b/hal/stm32f4/spim.h
@@ -44,6 +44,8 @@ void spim_init(spim_t *spim);
  */
 typedef void (*spim_xfer_complete)(spim_t *spim, uint16_t addr, void *read_buf, void *write_buf, uint16_t len, void *param);
 
+#define SPIM_OK			0
+#define SPIM_ERROR_BUSY -1	// Transfer already in progress
 
 /**
  * @brief start a spi master transfer
@@ -55,10 +57,17 @@ typedef void (*spim_xfer_complete)(spim_t *spim, uint16_t addr, void *read_buf, 
  * @param len write & read this many byte to/from the read/write buf's
  * @param complete call this when len bytes are transfered
  * @param param complete parameter
- * @return true if the transfer was started, false if the SPI bus was busy and the transfer could not be started
+ * @return number of bytes to be transferred if the transfer was started, or negative error code if the transfer could not be started
  */
-bool spim_xfer(spim_t *spim, spim_xfer_opts *opts, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param);
+int spim_xfer(spim_t *spim, spim_xfer_opts *opts, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param);
 
+/**
+ * @brief return true is the SPI master is busy
+ * @param spim spi master to use
+ * @return true when busy, false if it is OK to start a new transaction
+ *
+ */
+bool spim_busy(spim_t *spim);
 
 /**
  * @brief flush the current spi master xfer

--- a/hal/stm32f4/spim.h
+++ b/hal/stm32f4/spim.h
@@ -55,8 +55,9 @@ typedef void (*spim_xfer_complete)(spim_t *spim, uint16_t addr, void *read_buf, 
  * @param len write & read this many byte to/from the read/write buf's
  * @param complete call this when len bytes are transfered
  * @param param complete parameter
+ * @return true if the transfer was started, false if the SPI bus was busy and the transfer could not be started
  */
-void spim_xfer(spim_t *spim, spim_xfer_opts *opts, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param);
+bool spim_xfer(spim_t *spim, spim_xfer_opts *opts, uint16_t addr, void *read_buf, void *write_buf, int len, spim_xfer_complete complete, void *param);
 
 
 /**

--- a/hal/stm32f4/spim_hw.h
+++ b/hal/stm32f4/spim_hw.h
@@ -44,8 +44,10 @@ struct spim_t
 	void *xfer_complete_param;						///< completion parameter
 	dma_t *rx_dma;									///< optional dma used for rx (ie dont use isr, do it in hw)
 	dma_request_t rx_dma_req;						///< used by rx_dma
+	bool rx_completed;								///< true if the rx dma complete interrupt has been called
 	dma_t *tx_dma;									///< optional dma used for tx (ie dont use isr, do it in hw)
 	dma_request_t tx_dma_req;						///< used by tx_dma
+	bool tx_completed;								///< true if the tx dma complete interrupt has been called
 };
 
 


### PR DESCRIPTION
spim_xfer() now returns false if it failed to start the transfer.
Fixed a problem with non-DMA transfers where the rx would not complete
(disable the txne interrupt once all data sent).
Fixed a problem with DMA transfers - under load the DMA rx complete
interrupt can happen before the DMA tx complete interrupt.
The symptoms of the above problem were that the SPI transfers would suddenly stop with the software thinking that a transfer was still in progress. Only seemed to happen if you started a transfer immediately after one finished.